### PR TITLE
clang-format src/

### DIFF
--- a/src/core/autotuner_search_space/src/Pass.cpp
+++ b/src/core/autotuner_search_space/src/Pass.cpp
@@ -25,7 +25,7 @@
 #include <fstream>
 #include <string>
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/core/doall/include/arcana/gino/core/DOALL.hpp
+++ b/src/core/doall/include/arcana/gino/core/DOALL.hpp
@@ -68,7 +68,9 @@ protected:
    * Interface
    */
   BasicBlock *getBasicBlockExecutedOnlyByLastIterationBeforeExitingTask(
-      LoopContent *LDI, uint32_t taskIndex, BasicBlock &bb) override;
+      LoopContent *LDI,
+      uint32_t taskIndex,
+      BasicBlock &bb) override;
 };
 
 } // namespace arcana::gino

--- a/src/core/doall/include/arcana/gino/core/DOALLTask.hpp
+++ b/src/core/doall/include/arcana/gino/core/DOALLTask.hpp
@@ -25,7 +25,7 @@
 #include "noelle/core/Task.hpp"
 #include "noelle/core/SCCDAGAttrs.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/core/dswp/src/CFG.cpp
+++ b/src/core/dswp/src/CFG.cpp
@@ -97,17 +97,17 @@ void DSWP::generateLoopSubsetForStage(LoopContent *LDI, int taskIndex) {
       continue;
     visitedBBs.insert(originalB);
 
-    assert(task->isAnOriginalBasicBlock(originalB) &&
-           "Basic block not cloned!");
+    assert(task->isAnOriginalBasicBlock(originalB)
+           && "Basic block not cloned!");
     auto clonedB = task->getCloneOfOriginalBasicBlock(originalB);
 
-    if (!clonedB->getTerminator() ||
-        !clonedB->getTerminator()->isTerminator()) {
+    if (!clonedB->getTerminator()
+        || !clonedB->getTerminator()->isTerminator()) {
       auto postDominatingBB = this->originalFunctionDS->PDT.getNode(originalB)
                                   ->getParent()
                                   ->getBlock();
-      assert(loopExits.find(postDominatingBB) == loopExits.end() &&
-             "Loop exiting terminator not cloned by task!");
+      assert(loopExits.find(postDominatingBB) == loopExits.end()
+             && "Loop exiting terminator not cloned by task!");
 
       IRBuilder<> builder(clonedB);
       builder.Insert(BranchInst::Create(
@@ -116,7 +116,8 @@ void DSWP::generateLoopSubsetForStage(LoopContent *LDI, int taskIndex) {
 
     } else {
       for (auto successorBB = succ_begin(originalB);
-           successorBB != succ_end(originalB); ++successorBB) {
+           successorBB != succ_end(originalB);
+           ++successorBB) {
         queueToFindMissingBBs.push(*successorBB);
       }
     }

--- a/src/core/dswp/src/DSWP.cpp
+++ b/src/core/dswp/src/DSWP.cpp
@@ -26,11 +26,15 @@
 namespace arcana::gino {
 
 DSWP::DSWP(Noelle &n, bool forceParallelization, bool enableSCCMerging)
-    : ParallelizationTechniqueForLoopsWithLoopCarriedDataDependences{n,
-                                                                     forceParallelization},
-      minCores{0}, enableMergingSCC{enableSCCMerging}, queues{},
-      queueArrayType{nullptr}, sccToStage{}, stageArrayType{nullptr},
-      zeroIndexForBaseArray{nullptr} {
+  : ParallelizationTechniqueForLoopsWithLoopCarriedDataDependences{ n,
+                                                                    forceParallelization },
+    minCores{ 0 },
+    enableMergingSCC{ enableSCCMerging },
+    queues{},
+    queueArrayType{ nullptr },
+    sccToStage{},
+    stageArrayType{ nullptr },
+    zeroIndexForBaseArray{ nullptr } {
 
   /*
    * Fetch the function that dispatch the parallelized loop.
@@ -162,9 +166,9 @@ bool DSWP::canBeAppliedToLoop(LoopContent *LDI, Heuristics *h) const {
     errs()
         << "Parallelizer:    Loop " << loopID << " has " << averageInstructions
         << " number of sequential instructions on average per loop iteration\n";
-    errs() << "Parallelizer:    Loop " << loopID << " has "
-           << sequentialFraction
-           << " % sequential execution per loop iteration\n";
+    errs()
+        << "Parallelizer:    Loop " << loopID << " has " << sequentialFraction
+        << " % sequential execution per loop iteration\n";
     errs() << "Parallelizer:      It will not be partitioned enough for DSWP. "
               "The thresholds are at least "
            << averageInstructionThreshold
@@ -218,8 +222,8 @@ bool DSWP::apply(LoopContent *LDI, Heuristics *h) {
   /*
    * Check if the parallelization is worth it.
    */
-  if (!this->forceParallelization &&
-      this->partitioner->numberOfPartitions() == 1) {
+  if (!this->forceParallelization
+      && this->partitioner->numberOfPartitions() == 1) {
 
     /*
      * The parallelization isn't worth it as there is only one pipeline stage.
@@ -407,7 +411,9 @@ uint32_t DSWP::getMinimumNumberOfIdleCores(void) const {
   return this->minCores;
 }
 
-std::string DSWP::getName(void) const { return "DSWP"; }
+std::string DSWP::getName(void) const {
+  return "DSWP";
+}
 
 Transformation DSWP::getParallelizationID(void) const {
   return Transformation::DSWP_ID;

--- a/src/core/dswp/src/Queue.cpp
+++ b/src/core/dswp/src/Queue.cpp
@@ -447,4 +447,4 @@ void DSWP::pushValueQueues(LoopContent *LDI, Noelle &par, int taskIndex) {
   }
 }
 
-}
+} // namespace arcana::gino

--- a/src/core/enablers/src/EnablersManager.hpp
+++ b/src/core/enablers/src/EnablersManager.hpp
@@ -26,7 +26,7 @@
 #include "noelle/tools/LoopInvariantCodeMotion.hpp"
 #include "noelle/tools/SCEVSimplification.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/core/helix/include/arcana/gino/core/HELIX.hpp
+++ b/src/core/helix/include/arcana/gino/core/HELIX.hpp
@@ -34,7 +34,7 @@
 namespace arcana::gino {
 
 class HELIX
-    : public ParallelizationTechniqueForLoopsWithLoopCarriedDataDependences {
+  : public ParallelizationTechniqueForLoopsWithLoopCarriedDataDependences {
 public:
   /*
    * Methods
@@ -49,8 +49,8 @@ public:
 
   Function *getTaskFunction(void) const;
 
-  SCC *
-  getTheSequentialSCCThatCreatesTheSequentialPrologue(LoopContent *LDI) const;
+  SCC *getTheSequentialSCCThatCreatesTheSequentialPrologue(
+      LoopContent *LDI) const;
 
   bool doesHaveASequentialPrologue(LoopContent *LDI) const;
 
@@ -65,7 +65,8 @@ public:
 protected:
   virtual HELIXTask *createParallelizableTask(LoopContent *LDI, Heuristics *h);
 
-  virtual bool synchronizeTask(LoopContent *LDI, Heuristics *h,
+  virtual bool synchronizeTask(LoopContent *LDI,
+                               Heuristics *h,
                                HELIXTask *helixTask);
 
   virtual void invokeParallelizedLoop(LoopContent *LDI,
@@ -76,32 +77,39 @@ protected:
                                         HELIXTask *helixTask);
 
   void createLoadsAndStoresToSpilledLCD(
-      LoopContent *LDI, DataFlowResult *reachabilityDFR,
+      LoopContent *LDI,
+      DataFlowResult *reachabilityDFR,
       std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-      SpilledLoopCarriedDependence *spill, Value *spillEnvPtr);
+      SpilledLoopCarriedDependence *spill,
+      Value *spillEnvPtr);
 
   void insertStoresToSpilledLCD(
       LoopContent *LDI,
       std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-      SpilledLoopCarriedDependence *spill, Value *spillEnvPtr);
+      SpilledLoopCarriedDependence *spill,
+      Value *spillEnvPtr);
 
   void defineFrontierForLoadsToSpilledLCD(
-      LoopContent *LDI, DataFlowResult *reachabilityDFR,
+      LoopContent *LDI,
+      DataFlowResult *reachabilityDFR,
       std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-      SpilledLoopCarriedDependence *spill, DominatorSummary *originalLoopDS,
+      SpilledLoopCarriedDependence *spill,
+      DominatorSummary *originalLoopDS,
       std::unordered_set<BasicBlock *> &originalFrontierBlocks);
 
   void replaceUsesOfSpilledPHIWithLoads(
       LoopContent *LDI,
       std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-      SpilledLoopCarriedDependence *spill, Value *spillEnvPtr,
+      SpilledLoopCarriedDependence *spill,
+      Value *spillEnvPtr,
       DominatorSummary *originalLoopDS,
       std::unordered_set<BasicBlock *> &originalFrontierBlocks);
 
-  std::vector<SequentialSegment *>
-  identifySequentialSegments(LoopContent *originalLDI, LoopContent *LDI,
-                             DataFlowResult *reachabilityDFR,
-                             HELIXTask *helixTask);
+  std::vector<SequentialSegment *> identifySequentialSegments(
+      LoopContent *originalLDI,
+      LoopContent *LDI,
+      DataFlowResult *reachabilityDFR,
+      HELIXTask *helixTask);
 
   void squeezeSequentialSegments(LoopContent *LDI,
                                  std::vector<SequentialSegment *> *sss,
@@ -119,16 +127,17 @@ protected:
 
   virtual CallInst *injectSignalCall(IRBuilder<> &builder, uint32_t ssID);
 
-  virtual void
-  computeAndCachePointerOfPastSequentialSegment(HELIXTask *helixTask,
-                                                uint32_t ssID);
+  virtual void computeAndCachePointerOfPastSequentialSegment(
+      HELIXTask *helixTask,
+      uint32_t ssID);
 
-  virtual void
-  computeAndCachePointerOfFutureSequentialSegment(HELIXTask *helixTask,
-                                                  uint32_t ssID);
+  virtual void computeAndCachePointerOfFutureSequentialSegment(
+      HELIXTask *helixTask,
+      uint32_t ssID);
 
   virtual Value *getPointerOfSequentialSegment(HELIXTask *helixTask,
-                                               Value *ssArray, uint32_t ssID);
+                                               Value *ssArray,
+                                               uint32_t ssID);
 
   void inlineCalls(Task *task);
 
@@ -137,7 +146,9 @@ protected:
   void rewireLoopForPeriodicVariables(LoopContent *LDI);
 
   BasicBlock *getBasicBlockExecutedOnlyByLastIterationBeforeExitingTask(
-      LoopContent *LDI, uint32_t taskIndex, BasicBlock &bb) override;
+      LoopContent *LDI,
+      uint32_t taskIndex,
+      BasicBlock &bb) override;
 
   /*
    * Fields

--- a/src/core/helix/include/arcana/gino/core/HELIXTask.hpp
+++ b/src/core/helix/include/arcana/gino/core/HELIXTask.hpp
@@ -25,7 +25,7 @@
 #include "noelle/core/Task.hpp"
 #include "noelle/core/SCCDAGAttrs.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/core/helix/src/HELIX_spiller.cpp
+++ b/src/core/helix/src/HELIX_spiller.cpp
@@ -59,8 +59,8 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
     assert(phiSCC != nullptr);
     auto sccInfo = sccManager->getSCCAttrs(phiSCC);
     assert(sccInfo != nullptr);
-    if (isa<ReductionSCC>(sccInfo) || isa<InductionVariableSCC>(sccInfo) ||
-        isa<PeriodicVariableSCC>(sccInfo)) {
+    if (isa<ReductionSCC>(sccInfo) || isa<InductionVariableSCC>(sccInfo)
+        || isa<PeriodicVariableSCC>(sccInfo)) {
       continue;
     }
     if (loopIVManager->doesContributeToComputeAnInductionVariable(&phi)) {
@@ -98,7 +98,11 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
    */
   this->loopCarriedLoopEnvironmentBuilder =
       new LoopEnvironmentBuilder(this->noelle.getProgram()->getContext(),
-                                 phiTypes, nonReducablePHIs, {}, 1, 1);
+                                 phiTypes,
+                                 nonReducablePHIs,
+                                 {},
+                                 1,
+                                 1);
 
   /*
    * Fetch the unique user of the environment builder dedicated to spilled
@@ -127,8 +131,9 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
     auto preHeaderIndex = phi->getBasicBlockIndex(loopPreHeader);
     auto preHeaderV = phi->getIncomingValue(preHeaderIndex);
     builder.CreateStore(
-        preHeaderV, loopCarriedLoopEnvironmentBuilder->getEnvironmentVariable(
-                        envVariableID));
+        preHeaderV,
+        loopCarriedLoopEnvironmentBuilder->getEnvironmentVariable(
+            envVariableID));
   }
 
   std::unordered_map<BasicBlock *, BasicBlock *> cloneToOriginalBlockMap;
@@ -158,18 +163,24 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
     /*
      * Create GEP access of the environment variable at index i
      */
-    auto envPtr = envUser->createEnvironmentVariablePointer(entryBuilder, phiI,
+    auto envPtr = envUser->createEnvironmentVariablePointer(entryBuilder,
+                                                            phiI,
                                                             phiTypes[phiI]);
 
-    this->createLoadsAndStoresToSpilledLCD(
-        LDI, reachabilityDFR, cloneToOriginalBlockMap, spilled, envPtr);
+    this->createLoadsAndStoresToSpilledLCD(LDI,
+                                           reachabilityDFR,
+                                           cloneToOriginalBlockMap,
+                                           spilled,
+                                           envPtr);
   }
 }
 
 void HELIX::createLoadsAndStoresToSpilledLCD(
-    LoopContent *LDI, DataFlowResult *reachabilityDFR,
+    LoopContent *LDI,
+    DataFlowResult *reachabilityDFR,
     std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-    SpilledLoopCarriedDependence *spill, Value *spillEnvPtr) {
+    SpilledLoopCarriedDependence *spill,
+    Value *spillEnvPtr) {
 
   /*
    * Fetch task and loop
@@ -184,7 +195,9 @@ void HELIX::createLoadsAndStoresToSpilledLCD(
    * Store loop carried dependencies into the spill environment
    * Identify the basic block dominating all stores to the spill environment
    */
-  this->insertStoresToSpilledLCD(LDI, cloneToOriginalBlockMap, spill,
+  this->insertStoresToSpilledLCD(LDI,
+                                 cloneToOriginalBlockMap,
+                                 spill,
                                  spillEnvPtr);
 
   /*
@@ -195,19 +208,26 @@ void HELIX::createLoadsAndStoresToSpilledLCD(
    * environment
    */
   std::unordered_set<BasicBlock *> originalFrontierBlocks;
-  this->defineFrontierForLoadsToSpilledLCD(LDI, reachabilityDFR,
-                                           cloneToOriginalBlockMap, spill, DS,
+  this->defineFrontierForLoadsToSpilledLCD(LDI,
+                                           reachabilityDFR,
+                                           cloneToOriginalBlockMap,
+                                           spill,
+                                           DS,
                                            originalFrontierBlocks);
 
-  this->replaceUsesOfSpilledPHIWithLoads(LDI, cloneToOriginalBlockMap, spill,
-                                         spillEnvPtr, DS,
+  this->replaceUsesOfSpilledPHIWithLoads(LDI,
+                                         cloneToOriginalBlockMap,
+                                         spill,
+                                         spillEnvPtr,
+                                         DS,
                                          originalFrontierBlocks);
 }
 
 void HELIX::insertStoresToSpilledLCD(
     LoopContent *LDI,
     std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-    SpilledLoopCarriedDependence *spill, Value *spillEnvPtr) {
+    SpilledLoopCarriedDependence *spill,
+    Value *spillEnvPtr) {
 
   auto helixTask = static_cast<HELIXTask *>(this->tasks[0]);
   auto loopStructure = LDI->getLoopStructure();
@@ -251,9 +271,11 @@ void HELIX::insertStoresToSpilledLCD(
 }
 
 void HELIX::defineFrontierForLoadsToSpilledLCD(
-    LoopContent *LDI, DataFlowResult *reachabilityDFR,
+    LoopContent *LDI,
+    DataFlowResult *reachabilityDFR,
     std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-    SpilledLoopCarriedDependence *spill, DominatorSummary *originalLoopDS,
+    SpilledLoopCarriedDependence *spill,
+    DominatorSummary *originalLoopDS,
     std::unordered_set<BasicBlock *> &originalFrontierBlocks) {
   auto loopStructure = LDI->getLoopStructure();
   auto loopHeader = loopStructure->getHeader();
@@ -357,7 +379,8 @@ void HELIX::defineFrontierForLoadsToSpilledLCD(
         auto originalIncomingBlock =
             cloneToOriginalBlockMap.at(cloneIncomingBlock);
         originalUserBlock = originalLoopDS->DT.findNearestCommonDominator(
-            originalUserBlock, originalIncomingBlock);
+            originalUserBlock,
+            originalIncomingBlock);
       }
     }
 
@@ -401,7 +424,8 @@ void HELIX::defineFrontierForLoadsToSpilledLCD(
 void HELIX::replaceUsesOfSpilledPHIWithLoads(
     LoopContent *LDI,
     std::unordered_map<BasicBlock *, BasicBlock *> &cloneToOriginalBlockMap,
-    SpilledLoopCarriedDependence *spill, Value *spillEnvPtr,
+    SpilledLoopCarriedDependence *spill,
+    Value *spillEnvPtr,
     DominatorSummary *originalLoopDS,
     std::unordered_set<BasicBlock *> &originalFrontierBlocks) {
 
@@ -412,8 +436,8 @@ void HELIX::replaceUsesOfSpilledPHIWithLoads(
    * Insert a load in each frontier block, placed before any user/store in that
    * block
    */
-  std::unordered_set<User *> spillUsers{spill->getClone()->user_begin(),
-                                        spill->getClone()->user_end()};
+  std::unordered_set<User *> spillUsers{ spill->getClone()->user_begin(),
+                                         spill->getClone()->user_end() };
   for (auto originalBlock : originalFrontierBlocks) {
     auto cloneBlock = helixTask->getCloneOfOriginalBasicBlock(originalBlock);
 
@@ -426,9 +450,9 @@ void HELIX::replaceUsesOfSpilledPHIWithLoads(
     while (!I->isTerminator()) {
       auto isUserInst = spillUsers.find(I) != spillUsers.end();
       auto store = dyn_cast<StoreInst>(I);
-      auto isStoreInst =
-          store != nullptr && spill->environmentStores.find(store) !=
-                                  spill->environmentStores.end();
+      auto isStoreInst = store != nullptr
+                         && spill->environmentStores.find(store)
+                                != spill->environmentStores.end();
       if (!isUserInst && !isStoreInst) {
         I = I->getNextNode();
         continue;
@@ -438,8 +462,9 @@ void HELIX::replaceUsesOfSpilledPHIWithLoads(
     }
 
     IRBuilder<> spillValueBuilder(insertPoint);
-    auto spillLoad = spillValueBuilder.CreateLoad(
-        spillEnvPtr, "noelle.helix.spilled_variable");
+    auto spillLoad =
+        spillValueBuilder.CreateLoad(spillEnvPtr,
+                                     "noelle.helix.spilled_variable");
     spill->environmentLoads.insert(spillLoad);
 
     /*

--- a/src/core/heuristics/include/arcana/gino/core/Heuristics.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/Heuristics.hpp
@@ -41,19 +41,24 @@ public:
   Heuristics(Noelle &noelle);
 
   void adjustParallelizationPartitionForDSWP(
-      SCCDAGPartitioner *partitioner, SCCDAGAttrs &attrs, uint64_t numThreads,
+      SCCDAGPartitioner *partitioner,
+      SCCDAGAttrs &attrs,
+      uint64_t numThreads,
       std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity verbose);
 
 private:
-  void
-  minMaxMergePartition(SCCDAGPartitioner &partitioner, SCCDAGAttrs &attrs,
-                       uint64_t numThreads,
-                       std::function<bool(GenericSCC *scc)> canBeRematerialized,
-                       Verbosity verbose);
+  void minMaxMergePartition(
+      SCCDAGPartitioner &partitioner,
+      SCCDAGAttrs &attrs,
+      uint64_t numThreads,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized,
+      Verbosity verbose);
 
   void smallestSizeMergePartition(
-      SCCDAGPartitioner &partitioner, SCCDAGAttrs &attrs, uint64_t numThreads,
+      SCCDAGPartitioner &partitioner,
+      SCCDAGAttrs &attrs,
+      uint64_t numThreads,
       std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity verbose);
 

--- a/src/core/heuristics/include/arcana/gino/core/InvocationLatency.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/InvocationLatency.hpp
@@ -36,20 +36,23 @@ public:
   uint64_t latencyPerInvocation(SCC *scc);
 
   uint64_t latencyPerInvocation(
-      SCCDAGAttrs *, std::unordered_set<SCCSet *> &subsets,
+      SCCDAGAttrs *,
+      std::unordered_set<SCCSet *> &subsets,
       std::function<bool(GenericSCC *scc)> canBeRematerialized);
 
   uint64_t latencyPerInvocation(Instruction *inst);
 
   uint64_t queueLatency(Value *queueVal);
 
-  std::set<Value *> &
-  memoizeExternals(SCCDAGAttrs *, SCC *,
-                   std::function<bool(GenericSCC *scc)> canBeRematerialized);
+  std::set<Value *> &memoizeExternals(
+      SCCDAGAttrs *,
+      SCC *,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized);
 
-  std::set<SCC *> &
-  memoizeParents(SCCDAGAttrs *, SCC *,
-                 std::function<bool(GenericSCC *scc)> canBeRematerialized);
+  std::set<SCC *> &memoizeParents(
+      SCCDAGAttrs *,
+      SCC *,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized);
 
 private:
   Hot *profiles;

--- a/src/core/heuristics/include/arcana/gino/core/MinMaxSizePartitionAnalysis.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/MinMaxSizePartitionAnalysis.hpp
@@ -35,14 +35,18 @@ namespace arcana::gino {
 class MinMaxSizePartitionAnalysis : public PartitionCostAnalysis {
 public:
   MinMaxSizePartitionAnalysis(
-      InvocationLatency &IL, SCCDAGPartitioner &p, SCCDAGAttrs &attrs,
-      int cores, std::function<bool(GenericSCC *scc)> canBeRematerialized,
+      InvocationLatency &IL,
+      SCCDAGPartitioner &p,
+      SCCDAGAttrs &attrs,
+      int cores,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity v)
-      : PartitionCostAnalysis{IL, p, attrs, cores, canBeRematerialized, v} {};
+    : PartitionCostAnalysis{ IL, p, attrs, cores, canBeRematerialized, v } {};
 
-  void
-  checkIfShouldMerge(SCCSet *sA, SCCSet *sB,
-                     std::function<bool(GenericSCC *scc)> canBeRematerialized);
+  void checkIfShouldMerge(
+      SCCSet *sA,
+      SCCSet *sB,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized);
 };
 } // namespace arcana::gino
 

--- a/src/core/heuristics/include/arcana/gino/core/PartitionCostAnalysis.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/PartitionCostAnalysis.hpp
@@ -33,14 +33,18 @@ namespace arcana::gino {
 class PartitionCostAnalysis {
 public:
   PartitionCostAnalysis(
-      InvocationLatency &IL, SCCDAGPartitioner &p, SCCDAGAttrs &, int numCores,
+      InvocationLatency &IL,
+      SCCDAGPartitioner &p,
+      SCCDAGAttrs &,
+      int numCores,
       std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity verbose);
 
   void traverseAllPartitionSubsets();
 
   virtual void checkIfShouldMerge(
-      SCCSet *sA, SCCSet *sB,
+      SCCSet *sA,
+      SCCSet *sB,
       std::function<bool(GenericSCC *scc)> canBeRematerialized) = 0;
 
   void resetCandidateSubsetInfo();

--- a/src/core/heuristics/include/arcana/gino/core/SmallestSizePartitionAnalysis.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/SmallestSizePartitionAnalysis.hpp
@@ -34,13 +34,17 @@ namespace arcana::gino {
 class SmallestSizePartitionAnalysis : public PartitionCostAnalysis {
 public:
   SmallestSizePartitionAnalysis(
-      InvocationLatency &IL, SCCDAGPartitioner &p, SCCDAGAttrs &attrs,
-      int cores, std::function<bool(GenericSCC *scc)> canBeRematerialized,
+      InvocationLatency &IL,
+      SCCDAGPartitioner &p,
+      SCCDAGAttrs &attrs,
+      int cores,
+      std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity v)
-      : PartitionCostAnalysis{IL, p, attrs, cores, canBeRematerialized, v} {};
+    : PartitionCostAnalysis{ IL, p, attrs, cores, canBeRematerialized, v } {};
 
   void checkIfShouldMerge(
-      SCCSet *sA, SCCSet *sB,
+      SCCSet *sA,
+      SCCSet *sB,
       std::function<bool(GenericSCC *scc)> canBeRematerialized) override;
 };
 

--- a/src/core/heuristics/src/HeuristicsPass.cpp
+++ b/src/core/heuristics/src/HeuristicsPass.cpp
@@ -26,16 +26,22 @@
 using namespace llvm;
 using namespace arcana::gino;
 
-bool HeuristicsPass::doInitialization(Module &M) { return false; }
+bool HeuristicsPass::doInitialization(Module &M) {
+  return false;
+}
 
 void HeuristicsPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   return;
 }
 
-bool HeuristicsPass::runOnModule(Module &M) { return false; }
+bool HeuristicsPass::runOnModule(Module &M) {
+  return false;
+}
 
-HeuristicsPass::HeuristicsPass() : ModulePass{ID} { return; }
+HeuristicsPass::HeuristicsPass() : ModulePass{ ID } {
+  return;
+}
 
 Heuristics *HeuristicsPass::getHeuristics(Noelle &noelle) {
   return new Heuristics(noelle);
@@ -47,17 +53,18 @@ static RegisterPass<HeuristicsPass> X("heuristics", "Heuristics about code");
 
 // Next there is code to register your pass to "clang"
 static HeuristicsPass *_PassMaker = NULL;
-static RegisterStandardPasses
-    _RegPass1(PassManagerBuilder::EP_OptimizerLast,
-              [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
-                if (!_PassMaker) {
-                  PM.add(_PassMaker = new HeuristicsPass());
-                }
-              }); // ** for -Ox
-static RegisterStandardPasses
-    _RegPass2(PassManagerBuilder::EP_EnabledOnOptLevel0,
-              [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
-                if (!_PassMaker) {
-                  PM.add(_PassMaker = new HeuristicsPass());
-                }
-              }); // ** for -O0
+static RegisterStandardPasses _RegPass1(PassManagerBuilder::EP_OptimizerLast,
+                                        [](const PassManagerBuilder &,
+                                           legacy::PassManagerBase &PM) {
+                                          if (!_PassMaker) {
+                                            PM.add(_PassMaker =
+                                                       new HeuristicsPass());
+                                          }
+                                        }); // ** for -Ox
+static RegisterStandardPasses _RegPass2(
+    PassManagerBuilder::EP_EnabledOnOptLevel0,
+    [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+      if (!_PassMaker) {
+        PM.add(_PassMaker = new HeuristicsPass());
+      }
+    }); // ** for -O0

--- a/src/core/heuristics/src/InvocationLatency.cpp
+++ b/src/core/heuristics/src/InvocationLatency.cpp
@@ -22,7 +22,7 @@
 #include "arcana/gino/core/InvocationLatency.hpp"
 
 using namespace llvm;
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 
@@ -164,4 +164,4 @@ std::set<SCC *> &InvocationLatency::memoizeParents(
   return clonableParents[scc];
 }
 
-}
+} // namespace arcana::gino

--- a/src/core/heuristics/src/MinMaxSizePartitionAnalysis.cpp
+++ b/src/core/heuristics/src/MinMaxSizePartitionAnalysis.cpp
@@ -83,4 +83,4 @@ void MinMaxSizePartitionAnalysis::checkIfShouldMerge(
   }
 }
 
-}
+} // namespace arcana::gino

--- a/src/core/heuristics/src/PartitionCostAnalysis.cpp
+++ b/src/core/heuristics/src/PartitionCostAnalysis.cpp
@@ -125,4 +125,4 @@ void PartitionCostAnalysis::printCandidate(raw_ostream &stream) {
          << " Instruction count: " << numInstructionsInSetsBeingMerged << "\n";
 }
 
-}
+} // namespace arcana::gino

--- a/src/core/heuristics/src/SmallestSizePartitionAnalysis.cpp
+++ b/src/core/heuristics/src/SmallestSizePartitionAnalysis.cpp
@@ -58,4 +58,4 @@ void SmallestSizePartitionAnalysis::checkIfShouldMerge(
   // if (lowered == loweredCost && insts > instCount) return ;
 }
 
-}
+} // namespace arcana::gino

--- a/src/core/inliner/src/Inliner.cpp
+++ b/src/core/inliner/src/Inliner.cpp
@@ -24,9 +24,15 @@
 namespace arcana::gino {
 
 Inliner::Inliner()
-    : ModulePass{ID}, maxNumberOfFunctionCallsToInlinePerLoop{10},
-      maxProgramInstructions{50000}, fnsAffected{}, parentFns{}, childrenFns{},
-      loopsToCheck{}, depthOrderedFns{}, preOrderedLoops{} {
+  : ModulePass{ ID },
+    maxNumberOfFunctionCallsToInlinePerLoop{ 10 },
+    maxProgramInstructions{ 50000 },
+    fnsAffected{},
+    parentFns{},
+    childrenFns{},
+    loopsToCheck{},
+    depthOrderedFns{},
+    preOrderedLoops{} {
 
   return;
 }
@@ -65,8 +71,9 @@ bool Inliner::runOnModule(Module &M) {
    * Check if the program is already too big
    */
   auto programInstructions = noelle.numberOfProgramInstructions();
-  errs() << "Inliner:   Number of program instructions = "
-         << programInstructions << "\n";
+  errs()
+      << "Inliner:   Number of program instructions = " << programInstructions
+      << "\n";
   if (programInstructions >= this->maxProgramInstructions) {
     errs() << "Inliner:     There are too many instructions. We'll not inline "
               "anything\n";
@@ -395,7 +402,9 @@ bool Inliner::canInlineWithoutRecursiveLoop(Function *parentF,
   return true;
 }
 
-bool Inliner::inlineFunctionCall(Hot *p, Function *F, Function *childF,
+bool Inliner::inlineFunctionCall(Hot *p,
+                                 Function *F,
+                                 Function *childF,
                                  CallInst *call) {
 
   /*
@@ -431,17 +440,17 @@ bool Inliner::inlineFunctionCall(Hot *p, Function *F, Function *childF,
    * Try to inline the function.
    */
   if (this->verbose != Verbosity::Disabled) {
-    call->print(errs() << "Inliner:   Inlining in: " << F->getName() << " ("
-                       << p->getStaticInstructions(F)
-                       << " instructions. The inlining will add "
-                       << p->getStaticInstructions(childF)
-                       << " instructions), ");
+    call->print(errs()
+                << "Inliner:   Inlining in: " << F->getName() << " ("
+                << p->getStaticInstructions(F)
+                << " instructions. The inlining will add "
+                << p->getStaticInstructions(childF) << " instructions), ");
     errs() << "\n";
   }
   int loopIndAfterCall = getNextPreorderLoopAfter(F, call);
   auto &parentCalls = orderedCalls[F];
-  auto callInd = std::find(parentCalls.begin(), parentCalls.end(), call) -
-                 parentCalls.begin();
+  auto callInd = std::find(parentCalls.begin(), parentCalls.end(), call)
+                 - parentCalls.begin();
 
   /*
    * Inline the call.
@@ -483,7 +492,8 @@ int Inliner::getNextPreorderLoopAfter(Function *F, CallInst *call) {
 /*
  * Function and loop ordering
  */
-void Inliner::adjustLoopOrdersAfterInline(Function *parentF, Function *childF,
+void Inliner::adjustLoopOrdersAfterInline(Function *parentF,
+                                          Function *childF,
                                           int nextLoopInd) {
   bool parentHasLoops = preOrderedLoops.find(parentF) != preOrderedLoops.end();
   bool childHasLoops = preOrderedLoops.find(childF) != preOrderedLoops.end();
@@ -520,7 +530,8 @@ void Inliner::adjustLoopOrdersAfterInline(Function *parentF, Function *childF,
 // therefore depthOrdered and fnOrder [in collectInDepthOrderFns] doesn't take
 // into account the defferent function that never got an order. This causes the
 // number to be out between successive iterations of this inliner.
-void Inliner::adjustFnGraphAfterInline(Function *parentF, Function *childF,
+void Inliner::adjustFnGraphAfterInline(Function *parentF,
+                                       Function *childF,
                                        int callInd) {
   auto &parentCalled = orderedCalled[parentF];
   auto &childCalled = orderedCalled[childF];

--- a/src/core/inliner/src/Inliner.hpp
+++ b/src/core/inliner/src/Inliner.hpp
@@ -55,7 +55,10 @@ private:
   bool inlineCallsInvolvedInLoopCarriedDataDependences(Noelle &noelle,
                                                        SCCCAG *pcg);
   bool inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
-      Function *F, LoopContent *LDI, SCCCAG *pcg, Noelle &noelle);
+      Function *F,
+      LoopContent *LDI,
+      SCCCAG *pcg,
+      Noelle &noelle);
 
   void getFunctionsToInline(std::string filename);
 
@@ -68,7 +71,9 @@ private:
    */
   bool canInlineWithoutRecursiveLoop(Function *parentF, Function *childF);
 
-  bool inlineFunctionCall(Hot *p, Function *F, Function *childF,
+  bool inlineFunctionCall(Hot *p,
+                          Function *F,
+                          Function *childF,
                           CallInst *call);
 
   int getNextPreorderLoopAfter(Function *F, CallInst *call);

--- a/src/core/inliner/src/Inliner_loopCarried.cpp
+++ b/src/core/inliner/src/Inliner_loopCarried.cpp
@@ -97,9 +97,9 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependences(Noelle &noelle,
        * always takes priority and we don't parallelize nested loops at the
        * moment.
        */
-      DOALL doall{noelle};
-      if ((summaryNode->getNumberOfSubLoops() >= 1) &&
-          doall.canBeAppliedToLoop(LDI, nullptr)) {
+      DOALL doall{ noelle };
+      if ((summaryNode->getNumberOfSubLoops() >= 1)
+          && doall.canBeAppliedToLoop(LDI, nullptr)) {
 
         /*
          * The loop is a doall.
@@ -110,8 +110,8 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependences(Noelle &noelle,
           /*
            * Check if the sub-loop is enabled.
            */
-          if (std::find(toCheck.begin(), toCheck.end(), &child) ==
-              toCheck.end()) {
+          if (std::find(toCheck.begin(), toCheck.end(), &child)
+              == toCheck.end()) {
             return false;
           }
 
@@ -134,7 +134,10 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependences(Noelle &noelle,
        */
       auto inlinedCall =
           this->inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
-              F, LDI, pcg, noelle);
+              F,
+              LDI,
+              pcg,
+              noelle);
       inlined |= inlinedCall;
       if (inlined) {
         break;
@@ -175,7 +178,10 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependences(Noelle &noelle,
  * most memory edges to other internal/external values
  */
 bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
-    Function *F, LoopContent *LDI, SCCCAG *pcg, Noelle &noelle) {
+    Function *F,
+    LoopContent *LDI,
+    SCCCAG *pcg,
+    Noelle &noelle) {
   assert(pcg != nullptr);
   assert(LDI != nullptr);
 
@@ -317,9 +323,9 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
        * current loop size.
        */
       numberOfFunctionCallsToInline++;
-      if ((memEdgeCount > maxMemEdges) &&
-          (hot->getStaticInstructions(callF) <
-           hot->getStaticInstructions(loopStructure))) {
+      if ((memEdgeCount > maxMemEdges)
+          && (hot->getStaticInstructions(callF)
+              < hot->getStaticInstructions(loopStructure))) {
         maxMemEdges = memEdgeCount;
         inlineCall = call;
       }
@@ -341,8 +347,8 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
    * Check if there are too many loop-carried data dependences related to
    * function calls.
    */
-  if (numberOfFunctionCallsToInline >=
-      this->maxNumberOfFunctionCallsToInlinePerLoop) {
+  if (numberOfFunctionCallsToInline
+      >= this->maxNumberOfFunctionCallsToInlinePerLoop) {
     errs() << "Inliner:   The loop "
            << *loopStructure->getHeader()->getFirstNonPHI()
            << " has too many function calls involved in loop-carried data "

--- a/src/core/input_output/src/InputOutput.hpp
+++ b/src/core/input_output/src/InputOutput.hpp
@@ -24,7 +24,7 @@
 
 #include "noelle/core/SystemHeaders.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/core/parallelization_planner/src/Planner.hpp
+++ b/src/core/parallelization_planner/src/Planner.hpp
@@ -54,19 +54,25 @@ private:
 
   std::vector<LoopContent *> getLoopsToParallelize(Module &M, Noelle &par);
 
-  void removeLoopsNotWorthParallelizing(Noelle &noelle, Hot *profiles,
+  void removeLoopsNotWorthParallelizing(Noelle &noelle,
+                                        Hot *profiles,
                                         LoopForest *f);
 
   std::vector<LoopContent *> selectTheOrderOfLoopsToParallelize(
-      Noelle &noelle, Hot *profiles, noelle::LoopTree *tree,
-      uint64_t &maxTimeSaved, uint64_t &maxTimeSavedWithDOALLOnly);
+      Noelle &noelle,
+      Hot *profiles,
+      noelle::LoopTree *tree,
+      uint64_t &maxTimeSaved,
+      uint64_t &maxTimeSavedWithDOALLOnly);
 
-  std::pair<uint64_t, uint64_t>
-  evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
-                  const std::map<LoopStructure *, uint64_t> &timeSaved,
-                  const std::map<LoopStructure *, bool> &doallLoops);
+  std::pair<uint64_t, uint64_t> evaluateSavings(
+      Noelle &noelle,
+      noelle::LoopTree *tree,
+      const std::map<LoopStructure *, uint64_t> &timeSaved,
+      const std::map<LoopStructure *, bool> &doallLoops);
 
-  uint64_t evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
+  uint64_t evaluateSavings(Noelle &noelle,
+                           noelle::LoopTree *tree,
                            const std::map<LoopStructure *, uint64_t> &timeSaved,
                            std::function<bool(LoopStructure *)> considerLoop);
 };

--- a/src/core/parallelization_technique/include/arcana/gino/core/ParallelizationTechnique.hpp
+++ b/src/core/parallelization_technique/include/arcana/gino/core/ParallelizationTechnique.hpp
@@ -81,14 +81,15 @@ protected:
    * - one basic block per loop exit, which will jump to the exit block
    */
   virtual void addPredecessorAndSuccessorsBasicBlocksToTasks(
-      LoopContent *loopContent, std::vector<Task *> taskStructs);
+      LoopContent *loopContent,
+      std::vector<Task *> taskStructs);
 
   /*
    * Loop's environment
    */
-  virtual void
-  initializeEnvironmentBuilder(LoopContent *loopContent,
-                               std::set<uint32_t> nonReducableVars);
+  virtual void initializeEnvironmentBuilder(
+      LoopContent *loopContent,
+      std::set<uint32_t> nonReducableVars);
 
   virtual void initializeEnvironmentBuilder(LoopContent *loopContent,
                                             std::set<uint32_t> simpleVars,
@@ -113,7 +114,8 @@ protected:
   virtual void populateLiveInEnvironment(LoopContent *loopContent);
 
   virtual BasicBlock *performReductionToAllReducableLiveOutVariables(
-      LoopContent *loopContent, Value *numberOfThreadsExecuted);
+      LoopContent *loopContent,
+      Value *numberOfThreadsExecuted);
 
   /*
    * Task helpers for manipulating loop body clones
@@ -123,12 +125,13 @@ protected:
                                          int taskIndex,
                                          std::set<Instruction *> subset);
 
-  virtual void
-  cloneMemoryLocationsLocallyAndRewireLoop(LoopContent *loopContent,
-                                           int taskIndex);
+  virtual void cloneMemoryLocationsLocallyAndRewireLoop(
+      LoopContent *loopContent,
+      int taskIndex);
 
   virtual std::unordered_map<InductionVariable *, Value *>
-  cloneIVStepValueComputation(LoopContent *loopContent, int taskIndex,
+  cloneIVStepValueComputation(LoopContent *loopContent,
+                              int taskIndex,
                               IRBuilder<> &insertBlock);
 
   virtual void adjustStepValueOfPointerTypeIVToReflectPointerArithmetic(
@@ -146,33 +149,42 @@ protected:
 
   virtual Instruction *
   fetchOrCreatePHIForIntermediateProducerValueOfReducibleLiveOutVariable(
-      LoopContent *loopContent, int taskIndex, int envID,
-      BasicBlock *insertBasicBlock, DominatorSummary &taskDS);
+      LoopContent *loopContent,
+      int taskIndex,
+      int envID,
+      BasicBlock *insertBasicBlock,
+      DominatorSummary &taskDS);
 
   virtual void generateCodeToStoreExitBlockIndex(LoopContent *loopContent,
                                                  int taskIndex);
 
   virtual std::set<BasicBlock *> determineLatestPointsToInsertLiveOutStore(
-      LoopContent *loopContent, int taskIndex, Instruction *liveOut,
-      bool isReduced, DominatorSummary &taskDS);
+      LoopContent *loopContent,
+      int taskIndex,
+      Instruction *liveOut,
+      bool isReduced,
+      DominatorSummary &taskDS);
 
-  virtual void
-  setReducableVariablesToBeginAtIdentityValue(LoopContent *loopContent,
-                                              int taskIndex);
+  virtual void setReducableVariablesToBeginAtIdentityValue(
+      LoopContent *loopContent,
+      int taskIndex);
 
-  virtual Value *castToCorrectReducibleType(IRBuilder<> &builder, Value *value,
+  virtual Value *castToCorrectReducibleType(IRBuilder<> &builder,
+                                            Value *value,
                                             Type *targetType);
 
   virtual BasicBlock *getBasicBlockExecutedOnlyByLastIterationBeforeExitingTask(
-      LoopContent *loopContent, uint32_t taskIndex, BasicBlock &bb) = 0;
+      LoopContent *loopContent,
+      uint32_t taskIndex,
+      BasicBlock &bb) = 0;
 
   /*
    * General purpose helpers (that should be moved to parallelization_utils)
    */
   virtual void doNestedInlineOfCalls(Function *F, std::set<CallInst *> &calls);
 
-  virtual float
-  computeSequentialFractionOfExecution(LoopContent *loopContent) const;
+  virtual float computeSequentialFractionOfExecution(
+      LoopContent *loopContent) const;
 
   virtual float computeSequentialFractionOfExecution(
       LoopContent *loopContent,

--- a/src/tools/parallelizer_plan_info/src/Pass.cpp
+++ b/src/tools/parallelizer_plan_info/src/Pass.cpp
@@ -23,10 +23,15 @@
 #include "PlanInfo.hpp"
 
 static cl::opt<bool> PrintAllHeaders(
-    "info-print-all-headers", cl::ZeroOrMore, cl::Hidden,
+    "info-print-all-headers",
+    cl::ZeroOrMore,
+    cl::Hidden,
     cl::desc("Print the header of all loops with a parallel plan"));
 static cl::list<int> PrintHeaders(
-    "info-print-headers", cl::ZeroOrMore, cl::Hidden, cl::CommaSeparated,
+    "info-print-headers",
+    cl::ZeroOrMore,
+    cl::Hidden,
+    cl::CommaSeparated,
     cl::desc("Print the headers of some loops with a parallel plan"));
 
 namespace arcana::gino {
@@ -56,12 +61,12 @@ static RegisterStandardPasses _RegPass1(PassManagerBuilder::EP_OptimizerLast,
                                             PM.add(_PassMaker = new PlanInfo());
                                           }
                                         }); // ** for -Ox
-static RegisterStandardPasses
-    _RegPass2(PassManagerBuilder::EP_EnabledOnOptLevel0,
-              [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
-                if (!_PassMaker) {
-                  PM.add(_PassMaker = new PlanInfo());
-                }
-              }); // ** for -O0
+static RegisterStandardPasses _RegPass2(
+    PassManagerBuilder::EP_EnabledOnOptLevel0,
+    [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+      if (!_PassMaker) {
+        PM.add(_PassMaker = new PlanInfo());
+      }
+    }); // ** for -O0
 
 } // namespace arcana::gino

--- a/src/tools/parallelizer_plan_info/src/PlanInfo.cpp
+++ b/src/tools/parallelizer_plan_info/src/PlanInfo.cpp
@@ -24,7 +24,9 @@
 
 namespace arcana::gino {
 
-PlanInfo::PlanInfo() : ModulePass{ID}, printAllHeaders{false} { return; }
+PlanInfo::PlanInfo() : ModulePass{ ID }, printAllHeaders{ false } {
+  return;
+}
 
 bool PlanInfo::runOnModule(Module &M) {
   auto &noelle = getAnalysis<Noelle>();
@@ -56,8 +58,8 @@ bool PlanInfo::runOnModule(Module &M) {
       }
       auto order =
           std::stoi(mm->getMetadata(ls, "noelle.parallelizer.looporder"));
-      auto optimizations = {LoopContentOptimization::MEMORY_CLONING_ID,
-                            LoopContentOptimization::THREAD_SAFE_LIBRARY_ID};
+      auto optimizations = { LoopContentOptimization::MEMORY_CLONING_ID,
+                             LoopContentOptimization::THREAD_SAFE_LIBRARY_ID };
       auto ldi = noelle.getLoopContent(ls, optimizations);
       order2ldi[order] = ldi;
       return false;

--- a/src/tools/parallelizer_plan_info/src/PlanInfo.hpp
+++ b/src/tools/parallelizer_plan_info/src/PlanInfo.hpp
@@ -24,7 +24,7 @@
 
 #include "noelle/core/Noelle.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 

--- a/src/tools/time_saved/src/LoopEvaluation.cpp
+++ b/src/tools/time_saved/src/LoopEvaluation.cpp
@@ -23,10 +23,11 @@
 
 namespace arcana::gino {
 
-std::pair<uint64_t, uint64_t>
-TimeSaved::evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
-                           const std::map<LoopStructure *, uint64_t> &timeSaved,
-                           const std::map<LoopStructure *, bool> &doallLoops) {
+std::pair<uint64_t, uint64_t> TimeSaved::evaluateSavings(
+    Noelle &noelle,
+    noelle::LoopTree *tree,
+    const std::map<LoopStructure *, uint64_t> &timeSaved,
+    const std::map<LoopStructure *, bool> &doallLoops) {
 
   /*
    * Fetch the maximum time saved by any combination of loops nested from @tree
@@ -52,16 +53,18 @@ TimeSaved::evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
   return make_pair(rootLoopMaxTimeSaved, rootLoopMaxTimeSavedWithDOALL);
 }
 
-uint64_t
-TimeSaved::evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
-                           const std::map<LoopStructure *, uint64_t> &timeSaved,
-                           std::function<bool(LoopStructure *)> considerLoop) {
+uint64_t TimeSaved::evaluateSavings(
+    Noelle &noelle,
+    noelle::LoopTree *tree,
+    const std::map<LoopStructure *, uint64_t> &timeSaved,
+    std::function<bool(LoopStructure *)> considerLoop) {
 
   /*
    * Find the maximum savings per internal node up to the root of the tree.
    */
   std::map<LoopStructure *, uint64_t> maxTimeSaved;
-  auto f = [&maxTimeSaved, &timeSaved,
+  auto f = [&maxTimeSaved,
+            &timeSaved,
             &considerLoop](LoopTree *n, uint32_t treeLevel) -> bool {
     /*
      * Check if we should consider this loop.

--- a/src/tools/time_saved/src/LoopSelector.cpp
+++ b/src/tools/time_saved/src/LoopSelector.cpp
@@ -25,8 +25,11 @@
 namespace arcana::gino {
 
 std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
-    Noelle &noelle, Hot *profiles, noelle::LoopTree *tree,
-    uint64_t &maxTimeSaved, uint64_t &maxTimeSavedWithDOALLOnly) {
+    Noelle &noelle,
+    Hot *profiles,
+    noelle::LoopTree *tree,
+    uint64_t &maxTimeSaved,
+    uint64_t &maxTimeSavedWithDOALLOnly) {
   std::vector<LoopContent *> selectedLoops{};
 
   /*
@@ -41,14 +44,17 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
   std::map<LoopContent *, uint64_t> timeSavedLoops;
   std::map<LoopStructure *, bool> doallLoops;
   std::map<LoopStructure *, uint64_t> timeSavedPerLoop;
-  auto selector = [&noelle, &timeSavedLoops, &timeSavedPerLoop, profiles,
+  auto selector = [&noelle,
+                   &timeSavedLoops,
+                   &timeSavedPerLoop,
+                   profiles,
                    &doallLoops](LoopTree *n, uint32_t treeLevel) -> bool {
     /*
      * Fetch the loop.
      */
     auto ls = n->getLoop();
-    auto optimizations = {LoopContentOptimization::MEMORY_CLONING_ID,
-                          LoopContentOptimization::THREAD_SAFE_LIBRARY_ID};
+    auto optimizations = { LoopContentOptimization::MEMORY_CLONING_ID,
+                           LoopContentOptimization::THREAD_SAFE_LIBRARY_ID };
     auto ldi = noelle.getLoopContent(ls, optimizations);
 
     /*
@@ -101,8 +107,8 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
     /*
      * Compute the total amount of time saved by parallelizing this loop.
      */
-    auto savedTimeTotal = ((double)timeSavedLoops[ldi]) /
-                          ((double)profiles->getTotalInstructions());
+    auto savedTimeTotal = ((double)timeSavedLoops[ldi])
+                          / ((double)profiles->getTotalInstructions());
     savedTimeTotal *= 100;
 
     /*
@@ -174,10 +180,10 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
     /*
      * Compute the savings
      */
-    auto savedTimeRelative = ((double)timeSavedLoops[l]) /
-                             ((double)profiles->getTotalInstructions(ls));
-    auto savedTimeTotal = ((double)timeSavedLoops[l]) /
-                          ((double)profiles->getTotalInstructions());
+    auto savedTimeRelative = ((double)timeSavedLoops[l])
+                             / ((double)profiles->getTotalInstructions(ls));
+    auto savedTimeTotal = ((double)timeSavedLoops[l])
+                          / ((double)profiles->getTotalInstructions());
     savedTimeRelative *= 100;
     savedTimeTotal *= 100;
 
@@ -199,8 +205,9 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
     errs() << "TimeSaved: LoopSelector:      Coverage: " << hotness << "\%\n";
     errs() << "TimeSaved: LoopSelector:      Whole-program savings = "
            << savedTimeTotal << "%\n";
-    errs() << "TimeSaved: LoopSelector:      Loop savings = "
-           << savedTimeRelative << "%\n";
+    errs()
+        << "TimeSaved: LoopSelector:      Loop savings = " << savedTimeRelative
+        << "%\n";
   }
   errs() << "TimeSaved: LoopSelector: End\n";
 

--- a/src/tools/time_saved/src/Pass.cpp
+++ b/src/tools/time_saved/src/Pass.cpp
@@ -23,9 +23,13 @@
 
 namespace arcana::gino {
 
-TimeSaved::TimeSaved() : ModulePass{ID}, forceParallelization{true} { return; }
+TimeSaved::TimeSaved() : ModulePass{ ID }, forceParallelization{ true } {
+  return;
+}
 
-bool TimeSaved::doInitialization(Module &M) { return false; }
+bool TimeSaved::doInitialization(Module &M) {
+  return false;
+}
 
 bool TimeSaved::runOnModule(Module &M) {
   errs() << "TimeSaved: Start\n";
@@ -74,8 +78,12 @@ bool TimeSaved::runOnModule(Module &M) {
      */
     uint64_t maxTimeSaved = 0;
     uint64_t maxTimeSavedWithDOALLOnly = 0;
-    auto loopsToParallelize = this->selectTheOrderOfLoopsToParallelize(
-        noelle, profiles, tree, maxTimeSaved, maxTimeSavedWithDOALLOnly);
+    auto loopsToParallelize =
+        this->selectTheOrderOfLoopsToParallelize(noelle,
+                                                 profiles,
+                                                 tree,
+                                                 maxTimeSaved,
+                                                 maxTimeSavedWithDOALLOnly);
     programMaxTimeSaved += maxTimeSaved;
     programMaxTimeSavedWithDOALLOnly += maxTimeSavedWithDOALLOnly;
 
@@ -90,17 +98,17 @@ bool TimeSaved::runOnModule(Module &M) {
   /*
    * Print statistics.
    */
-  auto savedTimeTotal = ((double)programMaxTimeSaved) /
-                        ((double)profiles->getTotalInstructions());
+  auto savedTimeTotal = ((double)programMaxTimeSaved)
+                        / ((double)profiles->getTotalInstructions());
   savedTimeTotal *= 100;
   errs() << "TimeSaved:   Maximum time saved = " << savedTimeTotal << "% ("
          << programMaxTimeSaved << ")\n";
-  savedTimeTotal = ((double)programMaxTimeSavedWithDOALLOnly) /
-                   ((double)profiles->getTotalInstructions());
+  savedTimeTotal = ((double)programMaxTimeSavedWithDOALLOnly)
+                   / ((double)profiles->getTotalInstructions());
   savedTimeTotal *= 100;
-  errs() << "TimeSaved:   Maximum time saved with DOALL only = "
-         << savedTimeTotal << "% (" << programMaxTimeSavedWithDOALLOnly
-         << ")\n";
+  errs()
+      << "TimeSaved:   Maximum time saved with DOALL only = " << savedTimeTotal
+      << "% (" << programMaxTimeSavedWithDOALLOnly << ")\n";
 
   errs() << "TimeSaved: Exit\n";
   return false;
@@ -128,22 +136,23 @@ void TimeSaved::getAnalysisUsage(AnalysisUsage &AU) const {
 
 // Next there is code to register your pass to "opt"
 char arcana::gino::TimeSaved::ID = 0;
-static RegisterPass<arcana::gino::TimeSaved>
-    X("TimeSaved", "Print estimated time saved by parallelization");
+static RegisterPass<arcana::gino::TimeSaved> X(
+    "TimeSaved",
+    "Print estimated time saved by parallelization");
 
 // Next there is code to register your pass to "clang"
 static arcana::gino::TimeSaved *_PassMaker = NULL;
-static RegisterStandardPasses
-    _RegPass1(PassManagerBuilder::EP_OptimizerLast,
-              [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
-                if (!_PassMaker) {
-                  PM.add(_PassMaker = new arcana::gino::TimeSaved());
-                }
-              }); // ** for -Ox
-static RegisterStandardPasses
-    _RegPass2(PassManagerBuilder::EP_EnabledOnOptLevel0,
-              [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
-                if (!_PassMaker) {
-                  PM.add(_PassMaker = new arcana::gino::TimeSaved());
-                }
-              }); // ** for -O0
+static RegisterStandardPasses _RegPass1(
+    PassManagerBuilder::EP_OptimizerLast,
+    [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+      if (!_PassMaker) {
+        PM.add(_PassMaker = new arcana::gino::TimeSaved());
+      }
+    }); // ** for -Ox
+static RegisterStandardPasses _RegPass2(
+    PassManagerBuilder::EP_EnabledOnOptLevel0,
+    [](const PassManagerBuilder &, legacy::PassManagerBase &PM) {
+      if (!_PassMaker) {
+        PM.add(_PassMaker = new arcana::gino::TimeSaved());
+      }
+    }); // ** for -O0

--- a/src/tools/time_saved/src/TimeSaved.hpp
+++ b/src/tools/time_saved/src/TimeSaved.hpp
@@ -54,15 +54,20 @@ private:
    */
 
   std::vector<LoopContent *> selectTheOrderOfLoopsToParallelize(
-      Noelle &noelle, Hot *profiles, noelle::LoopTree *tree,
-      uint64_t &maxTimeSaved, uint64_t &maxTimeSavedWithDOALLOnly);
+      Noelle &noelle,
+      Hot *profiles,
+      noelle::LoopTree *tree,
+      uint64_t &maxTimeSaved,
+      uint64_t &maxTimeSavedWithDOALLOnly);
 
-  std::pair<uint64_t, uint64_t>
-  evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
-                  const std::map<LoopStructure *, uint64_t> &timeSaved,
-                  const std::map<LoopStructure *, bool> &doallLoops);
+  std::pair<uint64_t, uint64_t> evaluateSavings(
+      Noelle &noelle,
+      noelle::LoopTree *tree,
+      const std::map<LoopStructure *, uint64_t> &timeSaved,
+      const std::map<LoopStructure *, bool> &doallLoops);
 
-  uint64_t evaluateSavings(Noelle &noelle, noelle::LoopTree *tree,
+  uint64_t evaluateSavings(Noelle &noelle,
+                           noelle::LoopTree *tree,
                            const std::map<LoopStructure *, uint64_t> &timeSaved,
                            std::function<bool(LoopStructure *)> considerLoop);
 };

--- a/src/tools/time_saved/src/TimingModel.cpp
+++ b/src/tools/time_saved/src/TimingModel.cpp
@@ -25,7 +25,8 @@
 namespace arcana::gino {
 
 LoopTimingModel::LoopTimingModel(Noelle &noelle, LoopContent &ldi)
-    : n{noelle}, loop{ldi} {
+  : n{ noelle },
+    loop{ ldi } {
   return;
 }
 

--- a/src/tools/time_saved/src/TimingModel.hpp
+++ b/src/tools/time_saved/src/TimingModel.hpp
@@ -24,7 +24,7 @@
 
 #include "noelle/core/Noelle.hpp"
 
-using namespace arcana::noelle ;
+using namespace arcana::noelle;
 
 namespace arcana::gino {
 


### PR DESCRIPTION
Various files got incorrectly formatted because .clang-format was missing. Example of unformatting in 4bc1cb0. 

This PR is the result of `find src/ -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i`.

I can also just format DSWP.cpp (relevant to OutputSequenceSCC PR) if preferred.