### PR TITLE
[tests] add a failing test

### DIFF
--- a/tests/regression/DoallLastIteration2/test.cpp
+++ b/tests/regression/DoallLastIteration2/test.cpp
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  int *q = (int *)malloc(101 * sizeof(int));
+
+  int *old_q = q;
+  for (uint32_t i = 100; i >= argc; i--) {
+    q++;
+    *q = 42 + i;
+  }
+  *q = 43;
+  std::cout << "*q:  " << *q << std::endl;
+  std::cout << "q address diff: " << (q - old_q) * sizeof(int) << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
This added test is expected to fail under several noelle compilation options. One of the compilation options is as follows:
```
make FRONTEND_OPTIONS='-O1 -Xclang -disable-llvm-passes' PRE_MIDDLEEND_OPTIONS='-O1' NOELLE_OPTIONS='-noelle-pdg-check -noelle-verbose=3 -noelle-max-cores=8 -noelle-disable-helix -noelle-disable-dswp -noelle-disable-inliner -noelle-disable-loop-invariant-code-motion -noelle-disable-whilifier -noelle-disable-loop-distribution -noelle-disable-scev-simplification -noelle-disable-loop-aware-dependence-analyses -noelle-inliner-avoid-hoist-to-main' TOOLS_OPTIONS='-noelle-disable-privatizer -noelle-disable-dead' PARALLELIZATION_OPTIONS='-noelle-parallelizer-force' test_correctness &> compiler_output.txt ;
```