### PR TITLE
`doall` reads the metadata `gino.doall`

### DIFF
--- a/src/core/doall/src/DOALL_applicabilityGuard.cpp
+++ b/src/core/doall/src/DOALL_applicabilityGuard.cpp
@@ -43,10 +43,14 @@ bool DOALL::canBeAppliedToLoop(LoopContent *LDI, Heuristics *h) const {
   if (MM->doesHaveMetadata(loopStructure, "gino.doall")) {
     auto isDOALL = MM->getMetadata(loopStructure, "gino.doall");
     if (isDOALL == "yes") {
-      errs() << "DOALL: looporder " << LO << " is marked as DOALL\n";
+      if (this->verbose != Verbosity::Disabled) {
+        errs() << "DOALL: looporder " << LO << " is marked as DOALL\n";
+      }
       return true;
     } else if (isDOALL == "no") {
-      errs() << "DOALL: looporder " << LO << " is marked as non-DOALL\n";
+      if (this->verbose != Verbosity::Disabled) {
+        errs() << "DOALL: looporder " << LO << " is marked as non-DOALL\n";
+      }
       return false;
     }
   }

--- a/src/core/doall/src/DOALL_applicabilityGuard.cpp
+++ b/src/core/doall/src/DOALL_applicabilityGuard.cpp
@@ -25,15 +25,31 @@
 namespace arcana::gino {
 
 bool DOALL::canBeAppliedToLoop(LoopContent *LDI, Heuristics *h) const {
+  auto MM = this->n.getMetadataManager();
+  auto loopStructure = LDI->getLoopStructure();
+  auto LO = MM->getMetadata(loopStructure, "noelle.parallelizer.looporder");
+
   if (this->verbose != Verbosity::Disabled) {
-    errs() << "DOALL: Checking if the loop is DOALL\n";
+    auto ID = loopStructure->getID().value();
+    errs() << "DOALL: Checking if the loop (id=" << ID << ", order=" << LO
+           << ") is DOALL\n";
   }
 
   /*
    * Fetch information about the loop.
    */
-  auto loopStructure = LDI->getLoopStructure();
   auto loopEnv = LDI->getEnvironment();
+
+  if (MM->doesHaveMetadata(loopStructure, "gino.doall")) {
+    auto isDOALL = MM->getMetadata(loopStructure, "gino.doall");
+    if (isDOALL == "yes") {
+      errs() << "DOALL: looporder " << LO << " is marked as DOALL\n";
+      return true;
+    } else if (isDOALL == "no") {
+      errs() << "DOALL: looporder " << LO << " is marked as non-DOALL\n";
+      return false;
+    }
+  }
 
   /*
    * The loop must have one single exit path.

--- a/src/core/parallelization_planner/src/LoopSelector.cpp
+++ b/src/core/parallelization_planner/src/LoopSelector.cpp
@@ -22,6 +22,8 @@
 #include "Planner.hpp"
 #include "TimingModel.hpp"
 
+using namespace arcana::noelle;
+
 namespace arcana::gino {
 
 void Planner::removeLoopsNotWorthParallelizing(Noelle &noelle,
@@ -254,6 +256,11 @@ std::vector<LoopContent *> Planner::selectTheOrderOfLoopsToParallelize(
   tree->visitPreOrder(selector);
 
   /*
+   * Exporting DOALL information through `gino.doall` metadata
+   */
+  exportDoallMetadata(noelle, doallLoops);
+
+  /*
    * Filter out loops that should not be parallelized.
    */
   for (auto loopPair : timeSavedLoops) {
@@ -391,4 +398,14 @@ std::vector<LoopContent *> Planner::selectTheOrderOfLoopsToParallelize(
 
   return selectedLoops;
 }
+
+void Planner::exportDoallMetadata(
+    Noelle &noelle,
+    const std::map<LoopStructure *, bool> &loops) {
+  auto MM = noelle.getMetadataManager();
+  for (auto &[LS, isDoall] : loops) {
+    MM->addMetadata(LS, "gino.doall", isDoall ? "yes" : "no");
+  }
+}
+
 } // namespace arcana::gino

--- a/src/core/parallelization_planner/src/LoopSelector.cpp
+++ b/src/core/parallelization_planner/src/LoopSelector.cpp
@@ -21,8 +21,7 @@
  */
 #include "Planner.hpp"
 #include "TimingModel.hpp"
-
-using namespace arcana::noelle;
+#include "arcana/gino/core/DOALL.hpp"
 
 namespace arcana::gino {
 
@@ -237,11 +236,8 @@ std::vector<LoopContent *> Planner::selectTheOrderOfLoopsToParallelize(
     /*
      * Tag DOALL loops.
      */
-    if (loopTimeModel->getTimeSpentInCriticalPathPerIteration() == 0) {
-      doallLoops[ls] = true;
-    } else {
-      doallLoops[ls] = false;
-    }
+    DOALL doall(noelle);
+    doallLoops[ls] = doall.canBeAppliedToLoop(ldi, /*heuristics=*/nullptr);
 
     /*
      * Compute the maximum amount of time saved by any parallelization

--- a/src/core/parallelization_planner/src/Planner.hpp
+++ b/src/core/parallelization_planner/src/Planner.hpp
@@ -75,6 +75,9 @@ private:
                            noelle::LoopTree *tree,
                            const std::map<LoopStructure *, uint64_t> &timeSaved,
                            std::function<bool(LoopStructure *)> considerLoop);
+
+  void exportDoallMetadata(Noelle &noelle,
+                           const std::map<LoopStructure *, bool> &loops);
 };
 
 } // namespace arcana::gino


### PR DESCRIPTION
Some loops may have the metadata `gino.doall` attached. If this is the case, the DOALL module will trust its value.
The metadata value for `gino.doall` is either `"yes"` or `"no"`.
This is one step towards having a single point in the pipeline that decides the parallel plan (i.e. `gino-planner`, the policy) and another entity that only performs the transformation  (i.e. `gino-loops`, the mechanism)