### PR TITLE
Fix PeriodicVariables2

### DIFF
--- a/src/core/doall/src/DOALL_chunking.cpp
+++ b/src/core/doall/src/DOALL_chunking.cpp
@@ -24,6 +24,7 @@
 #include "arcana/noelle/core/SingleAccumulatorRecomputableSCC.hpp"
 #include "arcana/gino/core/DOALL.hpp"
 #include "arcana/gino/core/DOALLTask.hpp"
+#include "llvm/IR/IRBuilder.h"
 
 namespace arcana::gino {
 
@@ -130,6 +131,7 @@ void DOALL::rewireLoopToIterateChunks(LoopContent *LDI, DOALLTask *task) {
    * Generates code for periodic variable SCCs to match the DOALL chunking
    * strategy.
    */
+  PHINode *getOrInjectIterCounter = nullptr;
   for (auto scc : sccdag->getSCCs()) {
     auto sccInfo = sccManager->getSCCAttrs(scc);
     auto periodicVariableSCC = dyn_cast<PeriodicVariableSCC>(sccInfo);
@@ -157,17 +159,23 @@ void DOALL::rewireLoopToIterateChunks(LoopContent *LDI, DOALLTask *task) {
         && "DOALL: PHINode in periodic variable SCC doesn't have exactly two entries!");
     auto taskPHI = cast<PHINode>(task->getCloneOfOriginalInstruction(phi));
 
+    // We have a crummy assumption that periodic vars have only two incoming
+    // vals in their phis, so determine which is from the entry and which is
+    // from the latch
     uint64_t entryBlock = 0;
     uint64_t loopBlock = 0;
     if (phi->getIncomingValue(0) == initialValue) {
       entryBlock = 0;
       loopBlock = 1;
     } else {
+      // if the phinode doesnt have the incoming value for the periodic var,
+      // something is wrong with the PVSCC analysis
       assert(phi->getIncomingValue(1) == initialValue
              && "DOALL: periodic variable SCC selected the wrong PHINode!");
       entryBlock = 1;
       loopBlock = 0;
     }
+    // get clones of PVSCC vals
     auto taskLoopBlock =
         task->getCloneOfOriginalBasicBlock(phi->getIncomingBlock(loopBlock));
     assert(taskLoopBlock != nullptr);
@@ -177,14 +185,69 @@ void DOALL::rewireLoopToIterateChunks(LoopContent *LDI, DOALLTask *task) {
         task->getCloneOfOriginalInstruction(cast<Instruction>(loopValue));
     assert(taskLoopValue != nullptr);
 
-    /*
+    // create code to check if the PVSCC must chunkstep
+    auto isChunkCompleted =
+        cast<SelectInst>(chunkPHI->getIncomingValueForBlock(taskLoopBlock))
+            ->getCondition();
+
+    // set builder insert points
+    IRBuilder<> headerBuilder(task->getCloneOfOriginalBasicBlock(
+        LDI->getLoopStructure()->getHeader()));
+    headerBuilder.SetInsertPoint(&*headerBuilder.GetInsertBlock()->begin());
+    IRBuilder<> latchBuilder(task->getCloneOfOriginalBasicBlock(
+        *LDI->getLoopStructure()->getLatches().begin()));
+    latchBuilder.SetInsertPoint(latchBuilder.GetInsertBlock()->getTerminator());
+
+    // PVSCC will use the absolute iteration as part of our handling for them:
+    // get the counter for that or inject it
+    if (getOrInjectIterCounter == nullptr) {
+      /*
+       * Determine value of the start of this core's next chunk
+       * from the beginning of the next core's chunk.
+       * Formula: (next_chunk_initialValue + (step_size * (num_cores - 1) *
+       * chunk_size)) % period
+       */
+
+      // acquire the info needed to chunkstep *the absolute iteration counter*
+      auto onesValueForChunking = ConstantInt::get(chunkCounterType, 1);
+      auto coreIDxChunkSize = entryBuilder.CreateMul(task->taskInstanceID,
+                                                     task->chunkSizeArg,
+                                                     "coreIdx_X_chunkSize");
+      auto numCoresMinus1 = entryBuilder.CreateSub(task->numTaskInstances,
+                                                   onesValueForChunking,
+                                                   "numCoresMinus1");
+      auto chunkStepSize = entryBuilder.CreateMul(numCoresMinus1,
+                                                  task->chunkSizeArg,
+                                                  "numCoresMinus1_X_chunkSize");
+
+      // build absolute iteration counter
+      getOrInjectIterCounter = headerBuilder.CreatePHI(
+          llvm::Type::getInt64Ty(headerBuilder.getContext()),
+          2,
+          "iterCounter");
+      getOrInjectIterCounter->addIncoming(coreIDxChunkSize, preheaderClone);
+      auto iterIncrement =
+          latchBuilder.CreateAdd(getOrInjectIterCounter, onesValueForChunking);
+      auto iterChunkStep = latchBuilder.CreateAdd(iterIncrement, chunkStepSize);
+      auto iterSelect = latchBuilder.CreateSelect(isChunkCompleted,
+                                                  iterChunkStep,
+                                                  iterIncrement);
+      getOrInjectIterCounter->addIncoming(iterSelect,
+                                          latchBuilder.GetInsertBlock());
+    }
+
+    assert((getOrInjectIterCounter != nullptr)
+           && "DOALL_chunking: no iterCounter\n");
+
+    /* DD: we choose to not do this and instead replace the whole PVSCC with a
+    computation based on the iteration.
+     * DD: there are other options here but we kind of just arbitrarily select
+    this one. It is very convenient
+     * for capturing the 2-phis PVSCC.
      * Calculate the periodic variable's initial value for the task.
      * This value is: initialValue + step_size * ((task_id * chunk_size) %
      * period)
-     */
-    auto coreIDxChunkSize = entryBuilder.CreateMul(task->taskInstanceID,
-                                                   task->chunkSizeArg,
-                                                   "coreIdx_X_chunkSize");
+
     auto numSteps =
         entryBuilder.CreateSRem(coreIDxChunkSize, period, "numSteps");
     auto numStepsTrunc = entryBuilder.CreateTrunc(numSteps, step->getType());
@@ -195,56 +258,32 @@ void DOALL::rewireLoopToIterateChunks(LoopContent *LDI, DOALLTask *task) {
     auto chunkInitialValue = entryBuilder.CreateAdd(initialValue,
                                                     numStepsxStepSizeTrunc,
                                                     "initialValuePlusStep");
-    taskPHI->setIncomingValue(entryBlock, chunkInitialValue);
-
-    /*
-     * Determine value of the start of this core's next chunk
-     * from the beginning of the next core's chunk.
-     * Formula: (next_chunk_initialValue + (step_size * (num_cores - 1) *
-     * chunk_size)) % period
-     */
-    auto onesValueForChunking = ConstantInt::get(chunkCounterType, 1);
-    auto numCoresMinus1 = entryBuilder.CreateSub(task->numTaskInstances,
-                                                 onesValueForChunking,
-                                                 "numCoresMinus1");
-    auto chunkStepSize = entryBuilder.CreateMul(numCoresMinus1,
-                                                task->chunkSizeArg,
-                                                "numCoresMinus1_X_chunkSize");
-    auto chunkStepSizeTrunc =
-        entryBuilder.CreateTrunc(chunkStepSize, step->getType());
-    auto chunkStep =
-        entryBuilder.CreateMul(chunkStepSizeTrunc, step, "chunkStep");
+    taskPHI->setIncomingValue(entryBlock, chunkInitialValue);*/
 
     /*
      * Add the instructions for the calculation of the next chunk's start value
      * in the loop's body.
      */
-    IRBuilder<> loopBuilder(taskLoopBlock);
-    loopBuilder.SetInsertPoint(taskLoopBlock->getTerminator());
-    auto chunkStepTrunc =
-        loopBuilder.CreateTrunc(chunkStep, taskLoopValue->getType());
-    auto nextChunkValueBeforeMod =
-        loopBuilder.CreateAdd(taskLoopValue,
-                              chunkStepTrunc,
-                              "nextChunkValueBeforeMod");
-    auto periodTrunc =
-        loopBuilder.CreateTrunc(period, taskLoopValue->getType());
-    auto nextChunkValue = loopBuilder.CreateSRem(nextChunkValueBeforeMod,
-                                                 periodTrunc,
-                                                 "nextChunkValue");
 
-    /*
-     * Determine if we have reached the end of the chunk, and choose the
-     * periodic variable's next value accordingly.
-     */
-    auto isChunkCompleted =
-        cast<SelectInst>(chunkPHI->getIncomingValueForBlock(taskLoopBlock))
-            ->getCondition();
-    auto nextValue = loopBuilder.CreateSelect(isChunkCompleted,
-                                              nextChunkValue,
-                                              taskLoopValue,
-                                              "nextValue");
-    taskPHI->setIncomingValueForBlock(taskLoopBlock, nextValue);
+    headerBuilder.SetInsertPoint(
+        &*headerBuilder.GetInsertBlock()->getFirstInsertionPt());
+    // If there's some problem in here, consider whether e.g. the initialValue
+    // might be an instruction or smth that would need to be replaced w/ a
+    // corresponding clone from inside the task
+    auto period64 =
+        headerBuilder.CreateSExt(period, getOrInjectIterCounter->getType());
+    auto pvIter =
+        headerBuilder.CreateSRem(getOrInjectIterCounter, period64, "pvIter");
+    auto step64 =
+        headerBuilder.CreateSExt(step, getOrInjectIterCounter->getType());
+    auto pvStepXpvIter =
+        headerBuilder.CreateMul(step64, pvIter, "pvStepXpvIter");
+    auto pvSITrunc =
+        headerBuilder.CreateTrunc(pvStepXpvIter, initialValue->getType());
+    auto pvCurr = headerBuilder.CreateAdd(pvSITrunc, initialValue, "pvCurr");
+    assert((taskPHI->getType() == pvCurr->getType())
+           && "issue with typing periodic variables in doall_chunking\n");
+    taskPHI->replaceAllUsesWith(pvCurr);
   }
 
   /*

--- a/src/core/doall/src/DOALL_parallelization.cpp
+++ b/src/core/doall/src/DOALL_parallelization.cpp
@@ -213,6 +213,10 @@ bool DOALL::apply(LoopContent *LDI, Heuristics *h) {
   if (this->verbose >= Verbosity::Maximal) {
     errs() << "DOALL:  Rewired induction variables and reducible variables\n";
   }
+  if (this->verbose >= Verbosity::Maximal) {
+    doallTask->getTaskBody()->print(errs() << "DOALL:  Post chunking loop:\n");
+    errs() << "\n";
+  }
 
   /*
    * Store final results to loop live-out variables. Note this occurs after

--- a/src/core/helix/src/HELIX_stepper.cpp
+++ b/src/core/helix/src/HELIX_stepper.cpp
@@ -521,8 +521,7 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
       continue;
     }
 
-    // set builder insert points. Pray these LoC will work for HELIX, copied
-    // straight from DOALL
+    // Set builder insert points.
     IRBuilder<> headerBuilder(task->getCloneOfOriginalBasicBlock(
         LDI->getLoopStructure()->getHeader()));
     headerBuilder.SetInsertPoint(&*headerBuilder.GetInsertBlock()->begin());
@@ -530,8 +529,11 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
         *LDI->getLoopStructure()->getLatches().begin()));
     latchBuilder.SetInsertPoint(latchBuilder.GetInsertBlock()->getTerminator());
 
-    // PVSCC will use the absolute iteration as part of our handling for them:
-    // get the counter for that or inject it
+    /*
+     * PeriodicVariableSCC will use the absolute iteration as part of our handling for them:
+     * get the counter for that or inject it
+     */
+
     if (getOrInjectIterCounter == nullptr) {
       /*
        * Determine value of the start of this core's next chunk
@@ -565,8 +567,11 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
     auto period = periodicInfo->getPeriod();
     auto taskPHI = cast<PHINode>(this->fetchCloneInTask(task, accumulatorPHI));
 
-    // rather than track the PVSCC with a phi and update the phi we just
-    // calculate the PVSCC val directly from the absolute iteration counter.
+    /*
+     * Rather than track the PVSCC with a phi and update the phi we just
+     * calculate the PVSCC val directly from the absolute iteration counter.
+     */
+
     headerBuilder.SetInsertPoint(
         &*headerBuilder.GetInsertBlock()->getFirstInsertionPt());
     auto period64 =

--- a/src/core/helix/src/HELIX_stepper.cpp
+++ b/src/core/helix/src/HELIX_stepper.cpp
@@ -505,6 +505,7 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
   /*
    * Iterate through periodic variables.
    */
+  PHINode *getOrInjectIterCounter = nullptr;
   auto sccManager = LDI->getSCCManager();
   for (auto sccInfo :
        sccManager->getSCCsOfKind(GenericSCC::SCCKind::PERIODIC_VARIABLE)) {
@@ -520,63 +521,68 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
       continue;
     }
 
+    // set builder insert points. Pray these LoC will work for HELIX, copied
+    // straight from DOALL
+    IRBuilder<> headerBuilder(task->getCloneOfOriginalBasicBlock(
+        LDI->getLoopStructure()->getHeader()));
+    headerBuilder.SetInsertPoint(&*headerBuilder.GetInsertBlock()->begin());
+    IRBuilder<> latchBuilder(task->getCloneOfOriginalBasicBlock(
+        *LDI->getLoopStructure()->getLatches().begin()));
+    latchBuilder.SetInsertPoint(latchBuilder.GetInsertBlock()->getTerminator());
+
+    // PVSCC will use the absolute iteration as part of our handling for them:
+    // get the counter for that or inject it
+    if (getOrInjectIterCounter == nullptr) {
+      /*
+       * Determine value of the start of this core's next chunk
+       * from the beginning of the next core's chunk.
+       * Formula: (next_chunk_initialValue + (step_size * (num_cores - 1) *
+       * chunk_size)) % period
+       */
+
+      // build absolute iteration counter
+      getOrInjectIterCounter = headerBuilder.CreatePHI(
+          llvm::Type::getInt64Ty(headerBuilder.getContext()),
+          2,
+          "iterCounter");
+      getOrInjectIterCounter->addIncoming(
+          task->coreArg,
+          preheaderClone); // start value for iter counter.
+      auto iterIncrement = latchBuilder.CreateAdd(
+          getOrInjectIterCounter,
+          task->numCoresArg); // when we increment iter it is always by numcores
+                              // because HELIX.
+      getOrInjectIterCounter->addIncoming(iterIncrement,
+                                          latchBuilder.GetInsertBlock());
+    }
+
     /*
      * Determine start value of the periodic variable for the task
-     *   core_start = original_start + (original_step_size * core_id % period)
+     *   core_start = original_start + (original_step_size * (core_id % period))
      */
     auto initialValue = periodicInfo->getInitialValue();
-    auto stepSize = periodicInfo->getStepValue();
+    auto step = periodicInfo->getStepValue();
     auto period = periodicInfo->getPeriod();
     auto taskPHI = cast<PHINode>(this->fetchCloneInTask(task, accumulatorPHI));
 
-    IRBuilder<> preheaderBuilder(preheaderClone->getTerminator());
-
-    auto stepXiteration = preheaderBuilder.CreateMul(
-        preheaderBuilder.CreateZExtOrTrunc(stepSize, task->coreArg->getType()),
-        task->coreArg,
-        "stepXiteration");
-    auto stepsModPeriod = preheaderBuilder.CreateSRem(
-        stepXiteration,
-        preheaderBuilder.CreateZExtOrTrunc(period, stepXiteration->getType()),
-        "stepsModPeriod");
-    auto offsetStartValue = preheaderBuilder.CreateAdd(
-        initialValue,
-        preheaderBuilder.CreateZExtOrTrunc(stepsModPeriod,
-                                           initialValue->getType()));
-
-    taskPHI->setIncomingValueForBlock(preheaderClone, offsetStartValue);
-
-    /*
-     * Replace update of the periodic variable with the following update:
-     *  new_val = (prev_val + step_size * num_cores) % period
-     */
-    assert(taskPHI->getNumIncomingValues() == 2
-           && "periodic variable accumulatorPHI more than 2 values!\n");
-    BasicBlock *computationBlock = nullptr;
-    if (taskPHI->getIncomingBlock(0) == preheaderClone)
-      computationBlock = taskPHI->getIncomingBlock(1);
-    else
-      computationBlock = taskPHI->getIncomingBlock(0);
-
-    IRBuilder<> computationBuilder(computationBlock->getTerminator());
-
-    auto stepXcores = computationBuilder.CreateMul(
-        computationBuilder.CreateZExtOrTrunc(stepSize,
-                                             task->numCoresArg->getType()),
-        task->numCoresArg,
-        "stepXnumCores");
-    auto offsetIncomingValue = computationBuilder.CreateAdd(
-        computationBuilder.CreateZExtOrTrunc(taskPHI, stepXcores->getType()),
-        stepXcores);
-    auto offsetIncomingValueModPeriod = computationBuilder.CreateSRem(
-        offsetIncomingValue,
-        computationBuilder.CreateZExtOrTrunc(period,
-                                             offsetIncomingValue->getType()));
-
-    taskPHI->setIncomingValueForBlock(
-        computationBlock,
-        computationBuilder.CreateZExtOrTrunc(offsetIncomingValueModPeriod,
-                                             taskPHI->getType()));
+    // rather than track the PVSCC with a phi and update the phi we just
+    // calculate the PVSCC val directly from the absolute iteration counter.
+    headerBuilder.SetInsertPoint(
+        &*headerBuilder.GetInsertBlock()->getFirstInsertionPt());
+    auto period64 =
+        headerBuilder.CreateSExt(period, getOrInjectIterCounter->getType());
+    auto pvIter =
+        headerBuilder.CreateSRem(getOrInjectIterCounter, period64, "pvIter");
+    auto step64 =
+        headerBuilder.CreateSExt(step, getOrInjectIterCounter->getType());
+    auto pvStepXpvIter =
+        headerBuilder.CreateMul(step64, pvIter, "pvStepXpvIter");
+    auto pvSITrunc =
+        headerBuilder.CreateTrunc(pvStepXpvIter, initialValue->getType());
+    auto pvCurr = headerBuilder.CreateAdd(pvSITrunc, initialValue, "pvCurr");
+    assert((taskPHI->getType() == pvCurr->getType())
+           && "issue with typing periodic variables in doall_chunking\n");
+    taskPHI->replaceAllUsesWith(pvCurr);
   }
 }
 

--- a/tests/regression/PeriodicVariables2/test.cpp
+++ b/tests/regression/PeriodicVariables2/test.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  auto ntimes = atoll(argv[1]);
+  ntimes *= 1000;
+
+  int flag1 = 0;
+  bool flag2 = false;
+  int flag3 = 10;
+  int grow = 0;
+
+  int i = 0;
+  uint64_t acc = 0;
+  while (i < ntimes) {
+    flag1 ^= 1;
+    flag2 = !flag2;
+    grow = flag3 * i;
+    acc += flag1 + flag2 + grow;
+    flag3 = -flag3;
+    i++;
+  }
+  std::cout << " acc: " << acc << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
NEW HANDLING OF PERIODIC SCCS IN DOALL AND GINO:
- We now break the loop carried dependence of these SCCs by introducing an absolute iteration counter into the loop and directly calculating the SCC value from the counter at each iteration.

HAS A SISTER PR FROM NOELLE, REQUIRES THE SISTER PR