### PR TITLE
Fixed compile warnings

### DIFF
--- a/src/core/doall/src/DOALL_parallelization.cpp
+++ b/src/core/doall/src/DOALL_parallelization.cpp
@@ -40,12 +40,6 @@ bool DOALL::apply(LoopContent *LDI, Heuristics *h) {
    */
   auto loopStructure = LDI->getLoopStructure();
   auto loopHeader = loopStructure->getHeader();
-  auto loopPreHeader = loopStructure->getPreHeader();
-
-  /*
-   * Fetch the loop function.
-   */
-  auto loopFunction = loopStructure->getFunction();
 
   /*
    * Fetch the environment of the loop.
@@ -130,9 +124,9 @@ bool DOALL::apply(LoopContent *LDI, Heuristics *h) {
 
     return true;
   };
-  auto isSkippable = [this, loopEnvironment, sccManager, doallTask](
-                         uint32_t id,
-                         bool isLiveOut) -> bool {
+  auto isSkippable = [loopEnvironment,
+                      sccManager,
+                      doallTask](uint32_t id, bool isLiveOut) -> bool {
     if (isLiveOut) {
       return false;
     }

--- a/src/core/dswp/include/arcana/gino/core/DSWPTask.hpp
+++ b/src/core/dswp/include/arcana/gino/core/DSWPTask.hpp
@@ -84,9 +84,9 @@ struct QueueInfo {
   std::unordered_map<Instruction *, int> consumerToPushIndex;
 
   QueueInfo(Instruction *p, Instruction *c, Type *type, bool isMemoryDependence)
-    : producer{ p },
-      dependentType{ type },
-      isMemoryDependence{ isMemoryDependence } {
+    : dependentType{ type },
+      isMemoryDependence{ isMemoryDependence },
+      producer{ p } {
     consumers.insert(c);
     if (isMemoryDependence) {
       dependentType = IntegerType::get(c->getContext(), 1);

--- a/src/core/dswp/src/CFG.cpp
+++ b/src/core/dswp/src/CFG.cpp
@@ -66,7 +66,6 @@ void DSWP::generateLoopSubsetForStage(LoopContent *LDI, int taskIndex) {
    * Create an empty basic block for all basic blocks in the loop to be
    * potentially used in the task
    */
-  auto &cxt = task->getTaskBody()->getContext();
   for (auto B : loopSummary->getBasicBlocks()) {
     if (!task->isAnOriginalBasicBlock(B)) {
       task->addBasicBlockStub(B);

--- a/src/core/dswp/src/DSWP.cpp
+++ b/src/core/dswp/src/DSWP.cpp
@@ -30,9 +30,9 @@ DSWP::DSWP(Noelle &n, bool forceParallelization, bool enableSCCMerging)
                                                                     forceParallelization },
     minCores{ 0 },
     enableMergingSCC{ enableSCCMerging },
+    sccToStage{},
     queues{},
     queueArrayType{ nullptr },
-    sccToStage{},
     stageArrayType{ nullptr },
     zeroIndexForBaseArray{ nullptr } {
 
@@ -154,7 +154,7 @@ bool DSWP::canBeAppliedToLoop(LoopContent *LDI, Heuristics *h) const {
   auto averageInstructionThreshold = 20;
   bool hasLittleExecution = averageInstructions < averageInstructionThreshold;
   auto minimumSequentialFraction = .5;
-  auto skipSCC = [this, sccManager](GenericSCC *scc) -> bool {
+  auto skipSCC = [this](GenericSCC *scc) -> bool {
     auto skip = this->canBeCloned(scc);
     return skip;
   };
@@ -294,7 +294,7 @@ bool DSWP::apply(LoopContent *LDI, Heuristics *h) {
   /*
    * Create the pipeline stages (technique tasks)
    */
-  for (auto i = 0; i < this->tasks.size(); ++i) {
+  for (size_t i = 0; i < this->tasks.size(); ++i) {
     auto task = (DSWPTask *)this->tasks[i];
 
     /*

--- a/src/core/dswp/src/Environment.cpp
+++ b/src/core/dswp/src/Environment.cpp
@@ -61,7 +61,7 @@ void DSWP::collectLiveInEnvInfo(LoopContent *LDI) {
       auto consumerSCC = sccdag->sccOfValue(consumer);
       auto consumerSCCAttrs = sccManager->getSCCAttrs(consumerSCC);
       if (this->canBeCloned(consumerSCCAttrs)) {
-        for (auto i = 0; i < tasks.size(); ++i) {
+        for (size_t i = 0; i < tasks.size(); ++i) {
           auto task = (DSWPTask *)tasks[i];
           if (task->clonableSCCs.find(consumerSCC) == task->clonableSCCs.end())
             continue;
@@ -113,7 +113,7 @@ void DSWP::collectLiveOutEnvInfo(LoopContent *LDI) {
     auto producerSCC = sccdag->sccOfValue(producer);
     auto producerSCCAttrs = sccManager->getSCCAttrs(producerSCC);
     if (this->canBeCloned(producerSCCAttrs)) {
-      for (auto i = 0; i < tasks.size(); ++i) {
+      for (size_t i = 0; i < tasks.size(); ++i) {
         auto task = (DSWPTask *)tasks[i];
         if (task->clonableSCCs.find(producerSCC) == task->clonableSCCs.end())
           continue;

--- a/src/core/dswp/src/Partition.cpp
+++ b/src/core/dswp/src/Partition.cpp
@@ -30,7 +30,7 @@ void DSWP::partitionSCCDAG(LoopContent *LDI, Heuristics *h) {
    * Prepare the initial partition.
    */
   auto sccManager = LDI->getSCCManager();
-  auto skipSCC = [this, sccManager](GenericSCC *scc) -> bool {
+  auto skipSCC = [this](GenericSCC *scc) -> bool {
     auto skip = this->canBeCloned(scc);
     return skip;
   };

--- a/src/core/dswp/src/Pipeline.cpp
+++ b/src/core/dswp/src/Pipeline.cpp
@@ -53,8 +53,8 @@ void DSWP::generateStagesFromPartitionedSCCs(LoopContent *LDI) {
      * Define its signature.
      */
     auto taskArgType = taskExecuter->arg_begin()->getType();
-    auto taskSignature =
-        cast<FunctionType>(cast<PointerType>(taskArgType)->getElementType());
+    auto taskSignature = cast<FunctionType>(
+        cast<PointerType>(taskArgType)->getPointerElementType());
 
     /*
      * Create task (stage), populating its SCCs
@@ -152,17 +152,6 @@ void DSWP::createPipelineFromStages(LoopContent *LDI, Noelle &par) {
   auto cm = par.getConstantsManager();
 
   /*
-   * Fetch the loop function.
-   */
-  auto loopSummary = LDI->getLoopStructure();
-  auto loopFunction = loopSummary->getFunction();
-
-  /*
-   * Fetch the module.
-   */
-  auto M = loopFunction->getParent();
-
-  /*
    * Allocate the environment array and add its live-in values.
    */
   this->allocateEnvironmentArray(LDI);
@@ -224,7 +213,7 @@ Value *DSWP::createStagesArrayFromStages(LoopContent *LDI,
       cast<Value>(funcBuilder.CreateAlloca(this->stageArrayType));
   auto stageCastType =
       PointerType::getUnqual(this->tasks[0]->getTaskBody()->getType());
-  for (int i = 0; i < this->numTaskInstances; ++i) {
+  for (size_t i = 0; i < this->numTaskInstances; ++i) {
     auto stage = this->tasks[i];
     auto stageIndex = cm->getIntegerConstant(i, 64);
     auto stagePtr = funcBuilder.CreateGEP(
@@ -255,7 +244,7 @@ Value *DSWP::createQueueSizesArrayFromStages(LoopContent *LDI,
   auto int64Type = tm->getIntegerType(64);
   auto queuesAlloca = cast<Value>(
       funcBuilder.CreateAlloca(ArrayType::get(int64Type, this->queues.size())));
-  for (int i = 0; i < this->queues.size(); ++i) {
+  for (size_t i = 0; i < this->queues.size(); ++i) {
     auto &queue = this->queues[i];
     auto queueIndex = cm->getIntegerConstant(i, 64);
     auto queuePtr = funcBuilder.CreateGEP(

--- a/src/core/helix/src/HELIX_dependences.cpp
+++ b/src/core/helix/src/HELIX_dependences.cpp
@@ -238,8 +238,7 @@ static void constructEdgesFromUseDefs(PDG *pdg) {
       auto user = U.getUser();
 
       if (isa<Instruction>(user) || isa<Argument>(user)) {
-        auto edge =
-            pdg->addVariableDataDependenceEdge(pdgValue, user, DG_DATA_RAW);
+        pdg->addVariableDataDependenceEdge(pdgValue, user, DG_DATA_RAW);
       }
     }
   }

--- a/src/core/helix/src/HELIX_lastIteration.cpp
+++ b/src/core/helix/src/HELIX_lastIteration.cpp
@@ -36,7 +36,6 @@ BasicBlock *HELIX::getBasicBlockExecutedOnlyByLastIterationBeforeExitingTask(
    */
   auto task = (HELIXTask *)this->tasks[taskIndex];
   assert(task != nullptr);
-  auto taskFunction = task->getTaskBody();
 
   /*
    * Check if we have a sequential prologue

--- a/src/core/helix/src/HELIX_linker.cpp
+++ b/src/core/helix/src/HELIX_linker.cpp
@@ -32,12 +32,6 @@ void HELIX::invokeParallelizedLoop(LoopContent *LDI,
   auto cm = this->noelle.getConstantsManager();
 
   /*
-   * Fetch the loop function.
-   */
-  auto loopSummary = LDI->getLoopStructure();
-  auto loopFunction = loopSummary->getFunction();
-
-  /*
    * Create the environment.
    * This will append store instructions to entryPointOfParallelizedLoop to
    * initialize the environment array.

--- a/src/core/helix/src/HELIX_parallelization.cpp
+++ b/src/core/helix/src/HELIX_parallelization.cpp
@@ -141,7 +141,6 @@ HELIXTask *HELIX::createParallelizableTask(LoopContent *LDI, Heuristics *h) {
    * dispatcher.
    */
   auto tm = noelle.getTypesManager();
-  auto int8 = tm->getIntegerType(8);
   auto int64 = tm->getIntegerType(64);
   auto ptrType = tm->getVoidPointerType();
   auto voidType = tm->getVoidType();
@@ -201,9 +200,9 @@ HELIXTask *HELIX::createParallelizableTask(LoopContent *LDI, Heuristics *h) {
 
     return false;
   };
-  auto isSkippable = [this, environment, sccManager, helixTask](
-                         uint32_t id,
-                         bool isLiveOut) -> bool {
+  auto isSkippable = [environment,
+                      sccManager,
+                      helixTask](uint32_t id, bool isLiveOut) -> bool {
     if (isLiveOut) {
       return false;
     }
@@ -486,7 +485,6 @@ bool HELIX::synchronizeTask(LoopContent *LDI,
   for (auto loopBodyExecutionInstPair : loopBodyExecutionMap) {
     auto originalI = loopBodyExecutionInstPair.first;
     auto loopBodyCloneI = loopBodyExecutionInstPair.second;
-    auto exitCloneI = helixTask->getCloneOfOriginalInstruction(originalI);
     helixTask->addInstruction(originalI, loopBodyCloneI);
   }
   if (this->lastIterationExecutionBlock) {

--- a/src/core/helix/src/HELIX_prologue.cpp
+++ b/src/core/helix/src/HELIX_prologue.cpp
@@ -93,8 +93,6 @@ SCC *HELIX::getTheSequentialSCCThatCreatesTheSequentialPrologue(
      * If it doesn't, then we don't have a preamble.
      */
     auto loopStructure = LDI->getLoopStructure();
-    auto loopHeader = loopStructure->getHeader();
-    auto foundHeader = false;
     for (auto instNode : preambleSCC->getNodes()) {
       auto inst = cast<Instruction>(instNode->getT());
       if (loopStructure->isALoopExit(inst)) {

--- a/src/core/helix/src/HELIX_scheduler.cpp
+++ b/src/core/helix/src/HELIX_scheduler.cpp
@@ -42,7 +42,6 @@ void HELIX::squeezeSequentialSegment(LoopContent *LDI,
   auto loops = LDI->getLoopHierarchyStructures();
   auto rootLoop = loops->getLoop();
   auto taskFunction = rootLoop->getHeader()->getParent();
-  auto taskDG = LDI->getLoopDG();
   DominatorTree taskDT(*taskFunction);
   PostDominatorTree taskPDT(*taskFunction);
   DominatorSummary taskDS(taskDT, taskPDT);

--- a/src/core/helix/src/HELIX_sequentialSegment.cpp
+++ b/src/core/helix/src/HELIX_sequentialSegment.cpp
@@ -38,7 +38,6 @@ SequentialSegment::SequentialSegment(Noelle &noelle,
    */
   auto loopStructure = LDI->getLoopStructure();
   auto loopFunction = loopStructure->getFunction();
-  auto loopHeader = loopStructure->getHeader();
   this->ID = ID;
   this->sccs = sccs;
 
@@ -442,17 +441,16 @@ DataFlowResult *HELIX::computeReachabilityFromInstructions(LoopContent *LDI) {
     gen.insert(i);
     return;
   };
-  auto computeOUT = [LDI, loopHeader](Instruction *inst,
-                                      Instruction *succ,
-                                      std::set<Value *> &OUT,
-                                      DataFlowResult *df) {
+  auto computeOUT = [loopHeader](Instruction *inst,
+                                 Instruction *succ,
+                                 std::set<Value *> &OUT,
+                                 DataFlowResult *df) {
     /*
      * Check if the successor is the header.
      * In this case, we do not propagate the reachable instructions.
      * We do this because we are interested in understanding the reachability of
      * instructions within a single iteration.
      */
-    auto succBB = succ->getParent();
     if (succ == &*loopHeader->begin()) {
       return;
     }

--- a/src/core/helix/src/HELIX_spiller.cpp
+++ b/src/core/helix/src/HELIX_spiller.cpp
@@ -78,7 +78,7 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
    */
   std::vector<Type *> phiTypes;
   std::set<uint32_t> nonReducablePHIs;
-  for (auto i = 0; i < clonedLoopCarriedPHIs.size(); ++i) {
+  for (size_t i = 0; i < clonedLoopCarriedPHIs.size(); ++i) {
     auto phiType = clonedLoopCarriedPHIs[i]->getType();
     phiTypes.push_back(phiType);
     nonReducablePHIs.insert(i);
@@ -125,7 +125,7 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
   loopCarriedLoopEnvironmentBuilder->generateEnvVariables(loopFunctionBuilder);
 
   IRBuilder<> builder(this->entryPointOfParallelizedLoop);
-  for (auto envVariableID = 0; envVariableID < originalLoopCarriedPHIs.size();
+  for (size_t envVariableID = 0; envVariableID < originalLoopCarriedPHIs.size();
        ++envVariableID) {
     auto phi = originalLoopCarriedPHIs[envVariableID];
     auto preHeaderIndex = phi->getBasicBlockIndex(loopPreHeader);
@@ -148,7 +148,7 @@ void HELIX::spillLoopCarriedDataDependencies(LoopContent *LDI,
    * For the pre header edge case, store this initial value at time of
    * allocation of the environment
    */
-  for (auto phiI = 0; phiI < clonedLoopCarriedPHIs.size(); phiI++) {
+  for (size_t phiI = 0; phiI < clonedLoopCarriedPHIs.size(); phiI++) {
     auto originalPHI = originalLoopCarriedPHIs[phiI];
     auto clonePHI = clonedLoopCarriedPHIs[phiI];
     auto spilled = new SpilledLoopCarriedDependence(originalPHI, clonePHI);
@@ -185,7 +185,6 @@ void HELIX::createLoadsAndStoresToSpilledLCD(
   /*
    * Fetch task and loop
    */
-  auto helixTask = static_cast<HELIXTask *>(this->tasks[0]);
   auto loopStructure = LDI->getLoopStructure();
   auto loopHeader = loopStructure->getHeader();
   auto originalLoopFunction = loopHeader->getParent();
@@ -231,15 +230,13 @@ void HELIX::insertStoresToSpilledLCD(
 
   auto helixTask = static_cast<HELIXTask *>(this->tasks[0]);
   auto loopStructure = LDI->getLoopStructure();
-  auto loopHeader = loopStructure->getHeader();
   auto loopPreHeader = loopStructure->getPreHeader();
-  auto headerClone = helixTask->getCloneOfOriginalBasicBlock(loopHeader);
   auto preHeaderClone = helixTask->getCloneOfOriginalBasicBlock(loopPreHeader);
 
   /*
    * Store loop carried values of the PHI into the environment
    */
-  for (auto inInd = 0; inInd < spill->getClone()->getNumIncomingValues();
+  for (uint32_t inInd = 0; inInd < spill->getClone()->getNumIncomingValues();
        ++inInd) {
     auto incomingBB = spill->getClone()->getIncomingBlock(inInd);
     if (incomingBB == preHeaderClone) {
@@ -371,7 +368,7 @@ void HELIX::defineFrontierForLoadsToSpilledLCD(
      * identify a strictly dominating block of the user
      */
     if (auto userPHI = dyn_cast<PHINode>(user)) {
-      for (auto i = 0; i < userPHI->getNumIncomingValues(); ++i) {
+      for (uint32_t i = 0; i < userPHI->getNumIncomingValues(); ++i) {
         if (spill->getClone() != userPHI->getIncomingValue(i)) {
           continue;
         }

--- a/src/core/helix/src/HELIX_stepper.cpp
+++ b/src/core/helix/src/HELIX_stepper.cpp
@@ -488,19 +488,12 @@ void HELIX::rewireLoopForIVsToIterateNthIterations(LoopContent *LDI) {
 void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
 
   /*
-   * Fetch the loop environment.
-   */
-  auto loopEnvironment = LDI->getEnvironment();
-
-  /*
    * Fetch loop information.
    */
   auto task = static_cast<HELIXTask *>(this->tasks[0]);
   auto loopStructure = LDI->getLoopStructure();
-  auto loopHeader = loopStructure->getHeader();
   auto loopPreHeader = loopStructure->getPreHeader();
   auto preheaderClone = task->getCloneOfOriginalBasicBlock(loopPreHeader);
-  auto headerClone = task->getCloneOfOriginalBasicBlock(loopHeader);
 
   /*
    * Iterate through periodic variables.
@@ -530,8 +523,8 @@ void HELIX::rewireLoopForPeriodicVariables(LoopContent *LDI) {
     latchBuilder.SetInsertPoint(latchBuilder.GetInsertBlock()->getTerminator());
 
     /*
-     * PeriodicVariableSCC will use the absolute iteration as part of our handling for them:
-     * get the counter for that or inject it
+     * PeriodicVariableSCC will use the absolute iteration as part of our
+     * handling for them: get the counter for that or inject it
      */
 
     if (getOrInjectIterCounter == nullptr) {

--- a/src/core/heuristics/include/arcana/gino/core/MinMaxSizePartitionAnalysis.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/MinMaxSizePartitionAnalysis.hpp
@@ -46,7 +46,7 @@ public:
   void checkIfShouldMerge(
       SCCSet *sA,
       SCCSet *sB,
-      std::function<bool(GenericSCC *scc)> canBeRematerialized);
+      std::function<bool(GenericSCC *scc)> canBeRematerialized) override;
 };
 } // namespace arcana::gino
 

--- a/src/core/heuristics/include/arcana/gino/core/PartitionCostAnalysis.hpp
+++ b/src/core/heuristics/include/arcana/gino/core/PartitionCostAnalysis.hpp
@@ -40,6 +40,8 @@ public:
       std::function<bool(GenericSCC *scc)> canBeRematerialized,
       Verbosity verbose);
 
+  virtual ~PartitionCostAnalysis() = default;
+
   void traverseAllPartitionSubsets();
 
   virtual void checkIfShouldMerge(

--- a/src/core/heuristics/src/MinMaxSizePartitionAnalysis.cpp
+++ b/src/core/heuristics/src/MinMaxSizePartitionAnalysis.cpp
@@ -31,7 +31,7 @@ void MinMaxSizePartitionAnalysis::checkIfShouldMerge(
   /*
    * Hard stop merging once we have fewer partitions than cores
    */
-  if (partitioner.getPartitionGraph()->numNodes() <= numCores)
+  if ((int)partitioner.getPartitionGraph()->numNodes() <= numCores)
     return;
 
   /*

--- a/src/core/heuristics/src/PartitionCostAnalysis.cpp
+++ b/src/core/heuristics/src/PartitionCostAnalysis.cpp
@@ -32,14 +32,14 @@ PartitionCostAnalysis::PartitionCostAnalysis(
     int cores,
     std::function<bool(GenericSCC *scc)> canBeRematerialized,
     Verbosity v)
-  : costIfAllSetsRunOnSeparateCores{ 0 },
-    totalInstructionCount{ 0 },
-    IL{ il },
-    sccToInstructionCountMap{},
+  : IL{ il },
     partitioner{ p },
     dagAttrs{ attrs },
     numCores{ cores },
     canBeRematerialized{ canBeRematerialized },
+    sccToInstructionCountMap{},
+    costIfAllSetsRunOnSeparateCores{ 0 },
+    totalInstructionCount{ 0 },
     verbose{ v } {
 
   /*

--- a/src/core/inliner/src/Inliner.cpp
+++ b/src/core/inliner/src/Inliner.cpp
@@ -27,12 +27,12 @@ Inliner::Inliner()
   : ModulePass{ ID },
     maxNumberOfFunctionCallsToInlinePerLoop{ 10 },
     maxProgramInstructions{ 50000 },
-    fnsAffected{},
     parentFns{},
     childrenFns{},
-    loopsToCheck{},
     depthOrderedFns{},
-    preOrderedLoops{} {
+    preOrderedLoops{},
+    fnsAffected{},
+    loopsToCheck{} {
 
   return;
 }
@@ -244,7 +244,7 @@ void Inliner::getFunctionsToInline(std::string filename) {
     std::string line;
     while (getline(infile, line)) {
       int fnInd = std::stoi(line);
-      assert(fnInd > 0 && fnInd < depthOrderedFns.size());
+      assert(fnInd > 0 && fnInd < (int)depthOrderedFns.size());
       fnsToCheck.insert(depthOrderedFns[fnInd]);
     }
   } else {
@@ -291,7 +291,7 @@ bool Inliner::inlineFnsOfLoopsToCGRoot(Hot *hot) {
   }
   sortInDepthOrderFns(orderedFns);
 
-  int fnIndex = 0;
+  size_t fnIndex = 0;
   std::set<Function *> fnsWillCheck(orderedFns.begin(), orderedFns.end());
   std::set<Function *> fnsToAvoid;
   auto inlined = false;
@@ -371,12 +371,11 @@ bool Inliner::inlineFnsOfLoopsToCGRoot(Hot *hot) {
       if (fnsWillCheck.find(parentF) != fnsWillCheck.end())
         continue;
       fnsWillCheck.insert(parentF);
-      auto insertIndex = 0;
+      size_t insertIndex = 0;
       assert(fnOrders.find(parentF) != fnOrders.end());
       auto parentFnOrder = fnOrders[parentF];
-      for (auto insertIndex = 0; insertIndex < orderedFns.size();
-           insertIndex++) {
-        auto currentFunction = orderedFns[insertIndex];
+      for (size_t i = 0; i < orderedFns.size(); i++) {
+        auto currentFunction = orderedFns[i];
         auto currentFunctionFnOrder = fnOrders[currentFunction];
         if (currentFunctionFnOrder > parentFnOrder) {
           break;
@@ -472,7 +471,7 @@ int Inliner::getNextPreorderLoopAfter(Function *F, CallInst *call) {
 
   auto &summaries = *preOrderedLoops[F];
   auto getSummaryIfHeader = [&](BasicBlock *BB) -> int {
-    for (auto i = 0; i < summaries.size(); ++i) {
+    for (size_t i = 0; i < summaries.size(); ++i) {
       if (summaries[i]->getHeader() == BB)
         return i;
     }
@@ -510,18 +509,18 @@ void Inliner::adjustLoopOrdersAfterInline(Function *parentF,
    */
   auto &parentLoops = *preOrderedLoops[parentF];
   auto &childLoops = *preOrderedLoops[childF];
-  auto childLoopCount = childLoops.size();
-  auto endInd = nextLoopInd + childLoopCount;
+  int childLoopCount = childLoops.size();
+  int endInd = nextLoopInd + childLoopCount;
 
   // NOTE(angelo): Adjust parent loops after the call site
   parentLoops.resize(parentLoops.size() + childLoopCount);
-  for (auto shiftIndex = parentLoops.size() - 1; shiftIndex >= endInd;
+  for (int shiftIndex = parentLoops.size() - 1; shiftIndex >= endInd;
        --shiftIndex) {
     parentLoops[shiftIndex] = parentLoops[shiftIndex - childLoopCount];
   }
 
   // NOTE(angelo): Insert inlined loops from child function
-  for (auto childIndex = nextLoopInd; childIndex < endInd; ++childIndex) {
+  for (size_t childIndex = nextLoopInd; childIndex < endInd; ++childIndex) {
     parentLoops[childIndex] = childLoops[childIndex - nextLoopInd];
   }
 }
@@ -539,20 +538,20 @@ void Inliner::adjustFnGraphAfterInline(Function *parentF,
 
   parentCalled.erase(parentCalled.begin() + callInd);
   if (!childCalled.empty()) {
-    auto childCallCount = childCalled.size();
-    auto endInsertAt = callInd + childCallCount;
+    int childCallCount = childCalled.size();
+    int endInsertAt = callInd + childCallCount;
 
     // Shift over calls after the inlined call to make room for called
     // function's calls
     parentCalled.resize(parentCalled.size() + childCallCount);
-    for (auto shiftIndex = parentCalled.size() - 1; shiftIndex >= endInsertAt;
+    for (int shiftIndex = parentCalled.size() - 1; shiftIndex >= endInsertAt;
          --shiftIndex) {
       parentCalled[shiftIndex] = parentCalled[shiftIndex - childCallCount];
     }
 
     // Insert the called function's calls starting from the position of the
     // inlined call
-    for (auto childIndex = callInd; childIndex < endInsertAt; ++childIndex) {
+    for (int childIndex = callInd; childIndex < endInsertAt; ++childIndex) {
       parentCalled[childIndex] = childCalled[childIndex - callInd];
     }
   }
@@ -744,21 +743,11 @@ void Inliner::createPreOrderedLoopSummariesFor(Function *F) {
     return;
   auto loops = collectPreOrderedLoopsFor(F, LI);
 
-  /*
-   * Define the function to get the LLVM loop.
-   */
-  auto getLLVMLoopFunction = [this](BasicBlock *h) -> Loop * {
-    auto f = h->getParent();
-    auto &LI = getAnalysis<LoopInfoWrapperPass>(*f).getLoopInfo();
-    auto loop = LI.getLoopFor(h);
-    return loop;
-  };
-
   // Create summaries for the loops
   preOrderedLoops[F] = new std::vector<LoopStructure *>();
   auto &orderedLoops = *preOrderedLoops[F];
   std::unordered_map<Loop *, LoopStructure *> summaryMap;
-  for (auto i = 0; i < loops->size(); ++i) {
+  for (size_t i = 0; i < loops->size(); ++i) {
 
     /*
      * Create the summary loop

--- a/src/core/inliner/src/Inliner.cpp
+++ b/src/core/inliner/src/Inliner.cpp
@@ -244,7 +244,7 @@ void Inliner::getFunctionsToInline(std::string filename) {
     std::string line;
     while (getline(infile, line)) {
       int fnInd = std::stoi(line);
-      assert(fnInd > 0 && fnInd < (int)depthOrderedFns.size());
+      assert(fnInd > 0 && (size_t)fnInd < depthOrderedFns.size());
       fnsToCheck.insert(depthOrderedFns[fnInd]);
     }
   } else {

--- a/src/core/inliner/src/Inliner_loopCarried.cpp
+++ b/src/core/inliner/src/Inliner_loopCarried.cpp
@@ -191,16 +191,6 @@ bool Inliner::inlineCallsInvolvedInLoopCarriedDataDependencesWithinLoop(
   auto hot = noelle.getProfiles();
 
   /*
-   * Fetch the SCC manager.
-   */
-  auto sccManager = LDI->getSCCManager();
-
-  /*
-   * Fetch the SCCDAG
-   */
-  auto SCCDAG = sccManager->getSCCDAG();
-
-  /*
    *inlineFunctionCall Fetch the loop structure.
    */
   auto loopStructure = LDI->getLoopStructure();

--- a/src/core/inliner/src/Printer.cpp
+++ b/src/core/inliner/src/Printer.cpp
@@ -50,7 +50,6 @@ void Inliner::printFnLoopOrder(Function *F) {
     return;
   auto count = 1;
   for (auto summary : *preOrderedLoops[F]) {
-    auto headerBB = summary->getHeader();
     errs() << "Inliner:   Loop " << count++
            << ", depth: " << summary->getNestingLevel() << "\n";
     // headerBB->print(errs()); errs() << "\n";

--- a/src/core/parallelization_planner/src/LoopSelector.cpp
+++ b/src/core/parallelization_planner/src/LoopSelector.cpp
@@ -38,7 +38,7 @@ void Planner::removeLoopsNotWorthParallelizing(Noelle &noelle,
      * Filter out loops that are not worth parallelizing.
      */
     errs() << "Planner:  Filter out loops not worth considering\n";
-    auto filter = [this, forest, profiles](LoopStructure *ls) -> bool {
+    auto filter = [profiles](LoopStructure *ls) -> bool {
       /*
        * Fetch the loop ID.
        */
@@ -148,7 +148,7 @@ void Planner::removeLoopsNotWorthParallelizing(Noelle &noelle,
        * Compute the print prefix.
        */
       std::string prefix{ "Planner:    " };
-      for (auto i = 1; i < treeLevel; i++) {
+      for (uint32_t i = 1; i < treeLevel; i++) {
         prefix.append("  ");
       }
 
@@ -215,11 +215,9 @@ std::vector<LoopContent *> Planner::selectTheOrderOfLoopsToParallelize(
   std::map<LoopContent *, uint64_t> timeSavedLoops;
   std::map<LoopStructure *, bool> doallLoops;
   std::map<LoopStructure *, uint64_t> timeSavedPerLoop;
-  auto selector = [&noelle,
-                   &timeSavedLoops,
-                   &timeSavedPerLoop,
-                   profiles,
-                   &doallLoops](LoopTree *n, uint32_t treeLevel) -> bool {
+  auto selector = [&noelle, &timeSavedLoops, &timeSavedPerLoop, &doallLoops](
+                      LoopTree *n,
+                      uint32_t treeLevel) -> bool {
     /*
      * Fetch the loop.
      */

--- a/src/core/parallelizer/src/Parallelizer_loops.cpp
+++ b/src/core/parallelizer/src/Parallelizer_loops.cpp
@@ -26,11 +26,6 @@ namespace arcana::gino {
 bool Parallelizer::parallelizeLoops(Noelle &noelle, Heuristics *heuristics) {
 
   /*
-   * Fetch the verbosity level.
-   */
-  auto verbosity = noelle.getVerbosity();
-
-  /*
    * Collect information about C++ code we link parallelized loops with.
    */
   auto M = noelle.getProgram();

--- a/src/tools/time_saved/src/LoopSelector.cpp
+++ b/src/tools/time_saved/src/LoopSelector.cpp
@@ -33,11 +33,6 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
   std::vector<LoopContent *> selectedLoops{};
 
   /*
-   * Fetch the verbosity.
-   */
-  auto verbose = noelle.getVerbosity();
-
-  /*
    * Compute the amount of time that can be saved by a parallelization technique
    * per loop.
    */
@@ -102,14 +97,6 @@ std::vector<LoopContent *> TimeSaved::selectTheOrderOfLoopsToParallelize(
      */
     auto loopIDOpt = ls->getID();
     assert(loopIDOpt);
-    auto loopID = loopIDOpt.value();
-
-    /*
-     * Compute the total amount of time saved by parallelizing this loop.
-     */
-    auto savedTimeTotal = ((double)timeSavedLoops[ldi])
-                          / ((double)profiles->getTotalInstructions());
-    savedTimeTotal *= 100;
 
     /*
      * The loop is worth parallelizing it.


### PR DESCRIPTION
All warnings have been addressed. There should be no warning when compiling with clang 14.0.6.
This PR passes all regression tests when used on top of Noelle's [PR168](https://github.com/arcana-lab/noelle/pull/168)